### PR TITLE
Fixes for ticket:3955

### DIFF
--- a/antlr/3.2/libantlr3c-3.2/src/antlr3filestream.c
+++ b/antlr/3.2/libantlr3c-3.2/src/antlr3filestream.c
@@ -104,11 +104,7 @@ antlr3AsciiFileStreamNew(pANTLR3_UINT8 fileName)
 ANTLR3_API ANTLR3_UINT32
 antlr3readAscii(pANTLR3_INPUT_STREAM    input, pANTLR3_UINT8 fileName)
 {
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  char *fileOpenMode = "rt"; /* on Windows do translation so that \n becomes \r\n */
-#else
-  char *fileOpenMode = "rb";  /* on Unixes don't bother, do it binary mode */
-#endif
+	char *fileOpenMode = "rb";  /* on Unixes don't bother, do it binary mode */
 
 	ANTLR3_FDSC		    infile;
 	ANTLR3_UINT32	    fSize;
@@ -191,28 +187,6 @@ antlr3Fread(ANTLR3_FDSC fdsc, ANTLR3_UINT32 count,  void * data)
   */
   ANTLR3_UINT32 total = 0;
   ANTLR3_UINT32 cnt = 0;
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  /* adrpo: 2010-09-24
-   * in windows we cannot use fread(data, fileSize) as fileSize could be *MORE* than
-   * the contents of the file because \r\n is translated to \n
-   */
-  while( !feof( fdsc ) )
-  {
-     /* Attempt to read in count bytes: */
-     cnt = fread( data, sizeof(char), count, fdsc );
-     if( ferror( fdsc ) )
-     {
-        perror( "ANTLR3: File read error" );
-        total = 0;
-        break;
-     }
-     else
-     {
-       /* Total up actual bytes read */
-       total += cnt;
-     }
-  }
-#else
   cnt = fread(data, (size_t)count, 1, fdsc);
   if( (cnt != 1) || ferror( fdsc ))
   {
@@ -221,7 +195,6 @@ antlr3Fread(ANTLR3_FDSC fdsc, ANTLR3_UINT32 count,  void * data)
   }
   else
     total = count;
-#endif
   return total;
 }
 

--- a/gc/cord/cord.am
+++ b/gc/cord/cord.am
@@ -1,7 +1,7 @@
 
 lib_LTLIBRARIES += libcord.la
 
-libcord_la_LIBADD = $(top_builddir)/libgc.la
+libcord_la_LIBADD = $(top_builddir)/libomcgc.la
 libcord_la_LDFLAGS = -version-info 1:3:0 -no-undefined
 libcord_la_CPPFLAGS = $(AM_CPPFLAGS)
 
@@ -13,7 +13,7 @@ libcord_la_SOURCES = \
 TESTS += cordtest$(EXEEXT)
 check_PROGRAMS += cordtest
 cordtest_SOURCES = cord/tests/cordtest.c
-cordtest_LDADD = $(top_builddir)/libgc.la $(top_builddir)/libcord.la
+cordtest_LDADD = $(top_builddir)/libomcgc.la $(top_builddir)/libcord.la
 
 EXTRA_DIST += \
         cord/tests/de.c \

--- a/gc/win32_threads.c
+++ b/gc/win32_threads.c
@@ -1671,7 +1671,10 @@ GC_INNER void GC_get_next_stack(char *start, char *limit,
 
 # if defined(GC_PTHREADS) && !defined(GC_PTHREADS_PARAMARK)
     /* Use pthread-based parallel mark implementation.    */
+#if !defined(__MINGW32__)
 #   define GC_PTHREADS_PARAMARK
+#endif
+
 # endif
 
 # if !defined(GC_PTHREADS_PARAMARK)


### PR DESCRIPTION
- remove special Windows handling of files in antlr/3.2/libantlr3c-3.2/src/antlr3filestream.c
- rename libgc.la to libomcgc.la in gc/cord/cord.am
- disable usage of pthreads for GC parallel marking in gc/win32_threads.c