### PR TITLE
make it possible to statically link sundials on Windows mingw

### DIFF
--- a/sundials/CMakeLists.txt
+++ b/sundials/CMakeLists.txt
@@ -225,7 +225,11 @@ IF(BUILD_SHARED_LIBS AND WIN32)
     "#ifdef BUILD_SUNDIALS_LIBRARY
 #define SUNDIALS_EXPORT __declspec(dllexport)
 #else
+#ifdef LINK_SUNDIALS_STATIC
+#define SUNDIALS_EXPORT
+#else
 #define SUNDIALS_EXPORT __declspec(dllimport)
+#endif
 #endif")
 ELSE(BUILD_SHARED_LIBS AND WIN32)
   SET(SUNDIALS_EXPORT "#define SUNDIALS_EXPORT")


### PR DESCRIPTION
- even if we build both static / dynamic libs
- if LINK_SUNDIALS_STATIC is defined then SUNDIALS_EXPORT is defined to empty instead of __declspec(dllimport)