### PR TITLE
Call ::bind instead of std::bind

### DIFF
--- a/graphstream/gs-netstream/c++/src/netstream-socket.cpp
+++ b/graphstream/gs-netstream/c++/src/netstream-socket.cpp
@@ -257,7 +257,7 @@ namespace netstream
 			self.sin_addr.s_addr = htonl(INADDR_ANY);
 
 			// Assign a port number to the socket
-			if ( bind(server_socket_, (struct sockaddr*)&self, sizeof(self)) != 0 )
+			if ( ::bind(server_socket_, (struct sockaddr*)&self, sizeof(self)) != 0 )
 				BailOnNetStreamSocketError("netstream::NetStreamSocket::accept() Unable to create listening socket");
 
 


### PR DESCRIPTION
This avoids problems with macOS 10.13 and FreeBSD.