### PR TITLE
fixes for MINGW

### DIFF
--- a/lpsolve/configure.ac
+++ b/lpsolve/configure.ac
@@ -18,7 +18,11 @@ case $host_os in
       else CCSHARED="+z";
     fi;;
   CYGWIN*)
-    SO=.dll;;
+    SO=.dll
+	SHARED_LIB=liblpsolve55.dll;;
+  mingw*)
+    SO=.dll
+	SHARED_LIB=liblpsolve55.dll;;
   linux)
     CCSHARED="-fPIC";;
   apple-darwin)

--- a/lpsolve/lp_types.h
+++ b/lpsolve/lp_types.h
@@ -183,7 +183,11 @@
   #if defined __cplusplus
     #define INLINE inline
   #elif (defined _WIN32) || (defined WIN32) || (defined _WIN64) || (defined WIN64)
+    #if defined(_MSC_VER)
     #define INLINE __inline
+	#else /* MINGW */
+    #define INLINE static
+	#endif
   #else
     #define INLINE static
   #endif


### PR DESCRIPTION
- fix library name to be liblpsolve55.dll not liblpsolve55.so
- fix INLINE definition for mingw