### PR TITLE
[cmake] Fix include directory for expat.

### DIFF
--- a/FMIL/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
+++ b/FMIL/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
@@ -37,7 +37,8 @@ endif(BUILD_tests)
 
 include(ConfigureChecks.cmake)
 
-include_directories(${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/lib)
+# expat_config.h is generated in the build folder of expat ITSELF!. So we add ${CMAKE_CURRENT_BINARY_DIR}
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/lib)
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -wd4996)
 endif(MSVC)


### PR DESCRIPTION
  - Use CMAKE_CURRENT_BINARY_DIR instead of CMAKE_BINARY_DIR.
    CMAKE_CURRENT_BINARY_DIR is the build directory corresponding
    to the folder where the current CMakeLists.txt is located.
    CMAKE_BINARY_DIR points to the TOP build directory. Which might not
    be the same as the former if the project is added as part of another
    parent project structure.