### PR TITLE
[cmake] Fix FMIL and CMinpack for installation.

### DIFF
--- a/CMinpack/cmake/CMakeLists.txt
+++ b/CMinpack/cmake/CMakeLists.txt
@@ -5,4 +5,4 @@ configure_file(cminpack.pc.in ${pkg_conf_file} @ONLY)
 install(FILES ${pkg_conf_file}
     DESTINATION ${CMINPACK_LIB_INSTALL_DIR}/pkgconfig/ COMPONENT pkgconfig)
 
-install(FILES FindCMinpack.cmake DESTINATION ${CMAKE_ROOT}/Modules)
+# install(FILES FindCMinpack.cmake DESTINATION ${CMAKE_ROOT}/Modules)

--- a/FMIL/CMakeLists.txt
+++ b/FMIL/CMakeLists.txt
@@ -84,7 +84,7 @@ IF(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE ${FMILIB_DEFAULT_BUILD_TYPE})
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
-SET(CMAKE_INSTALL_PREFIX ${FMILIB_INSTALL_PREFIX} CACHE INTERNAL "Prefix prepended to install directories" FORCE)
+# SET(CMAKE_INSTALL_PREFIX ${FMILIB_INSTALL_PREFIX} CACHE INTERNAL "Prefix prepended to install directories" FORCE)
 
 # debug_message is used to trace the build script
 function(debug_message)


### PR DESCRIPTION
  - It might not be possible to write to the ${CMAKE_ROOT} directory due
    to permissions. So for now we skip the installation of the
    FindCMinpack.cmake module.

  - FMIL! it is just bad. They change the installation prefix internally,
    add it to the cache and even force overwriting it to their own
    selected installation prefix. Just remove that part.