### PR TITLE
Fix boehm GC gc_dlopen() undef. referrnce and build as static lib 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(omc::3rd::FMIL::minizip ALIAS minizip)
 # We use pthreads API even on Windows
 set(CMAKE_USE_PTHREADS_INIT ON)
 
+set(GC_BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
 set(enable_java_finalization OFF CACHE BOOL "Support for java finalization")
 set(enable_gcj_support OFF CACHE BOOL "Support for gcj")
 set(enable_large_config ON CACHE BOOL "Optimize for large heap or root set")
@@ -51,17 +52,6 @@ if(MINGW)
 else(MINGW)
     target_compile_definitions(omcgc PUBLIC GC_THREADS)
 endif(MINGW)
-
-# We build GC as a shared library for now just to avoid surprises. Being linked
-# to two dlls and ending up with two instances of GC on Windows for example. We do
-# not have many shared libs, if any, as of now for building omc. But simulation
-# executables might. So if you change the build to static, remember to not link GC
-# to two dlls (or 1 dll and the final exe) simultaneously. GC uses global variables
-# a bit and this will be problematic.
-
-# So we can keep it as shared lib for now. This means it needs to be installed
-# alongside omc. So we add it to installation component "compiler"
-install(TARGETS omcgc COMPONENT compiler)
 
 # Finally add an alias for clarity purposes.
 add_library(omc::3rd::omcgc ALIAS omcgc)

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -105,7 +105,7 @@ include_directories(include)
 set(SRC alloc.c reclaim.c allchblk.c misc.c mach_dep.c os_dep.c
         mark_rts.c headers.c mark.c obj_map.c blacklst.c finalize.c
         new_hblk.c dbg_mlc.c malloc.c dyn_load.c typd_mlc.c ptr_chck.c
-        mallocx.c)
+        mallocx.c gc_dlopen.c)
 set(THREADDLLIBS)
 
 set(_HOST ${CMAKE_SYSTEM_PROCESSOR}-unknown-${CMAKE_SYSTEM})


### PR DESCRIPTION
- Add missing gc_dlopen.c to configuration.

  - The source file _gc_dlopen.c_ is not listed in the SRC variable of the
    CMake configuration. This leads to undefined references of GC_dlopen
    when the library is built as a STATIC library.

  - When building as shared library it does not happen because the SRC
    variable listing all source files is overridden to contain only the
    single source extra/gc.c (which I assume contains the missing definition

- Build Boehm GC as a static library as well

  - We now build gc as a static lib. This means there are no more shared
    libraries in compilation of omc (except libOpenModelicaCompiler itself
    if needed of course.)

  - This also means there is no need to install it with omc for using just
    omc. You will have to install it to use it with simulation executables
    of course.



