### PR TITLE
CMake improvments to 3rdParty libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,39 @@ add_library(omc::3rd::cminpack ALIAS cminpack)
 # FMIL
 set (FMILIB_GENERATE_DOXYGEN_DOC OFF CACHE BOOL "Generate doxygen doc target")
 set (FMILIB_BUILD_TESTS OFF CACHE BOOL "Build tests")
+set (FMILIB_BUILD_SHARED_LIB OFF CACHE BOOL "Build the library as shared (dll/so/dylib).")
 omc_add_subdirectory(FMIL)
+
 # For now we deal with FMIL's nonsensical structure here. They really need to
-# fix up their cmake usage. It is their default build system and it is used in
+# fix up their structure as a whole! It is quite non-conventional.
+# They also need to fix their cmake usage. It is their default build system and it is used in
 # very contrived and unusual ways.
-target_include_directories(fmilib INTERFACE ${FMILibrary_SOURCE_DIR}/install/include)
+
+# We create a top level 'include' directory that matches their include structure when FMIL is installed-to-be-used.
+# This is how every library should be. That way when you install the library you just change the include
+# path and every include will be resolved as it was during build time.  Ideally it should even be in  'include/FMIL/'
+# but hat won't match how they install their files right now.
+file(MAKE_DIRECTORY ${FMILibrary_SOURCE_DIR}/include)
+# Do not ask me why the fmilib.h is in the cmake.config directory.
+file(COPY ${FMILibrary_SOURCE_DIR}/Config.cmake/fmilib.h DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Import/include/FMI DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Import/include/FMI1 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Import/include/FMI2 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+
+# This files 
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/FMI DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/FMI1 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/FMI2 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/JM DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+
+file(COPY ${FMILibrary_SOURCE_DIR}/ThirdParty/FMI/default/FMI1 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+file(COPY ${FMILibrary_SOURCE_DIR}/ThirdParty/FMI/default/FMI2 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+
+file(COPY ${FMILibrary_BINARY_DIR}/fmilib_config.h DESTINATION ${FMILibrary_SOURCE_DIR}/include)
+
+# We give this new directory as include dir for targets that depend on FMIL. 
+target_include_directories(fmilib INTERFACE ${FMILibrary_SOURCE_DIR}/include)
 add_library(omc::3rd::fmilib::static ALIAS fmilib)
 add_library(omc::3rd::FMIL::minizip ALIAS minizip)
 

--- a/antlr/3.2/libantlr3c-3.2/CMakeLists.txt
+++ b/antlr/3.2/libantlr3c-3.2/CMakeLists.txt
@@ -3,11 +3,58 @@ cmake_minimum_required(VERSION 3.14)
 
 file(GLOB ANTLR_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
 
+option(ANTLR3_NODEBUGGER "Turns off default flags that include the antlr debugger in the runtime. Specify to remove debugger and the socket dependancies" ON)
+option(ANTLR3_USE_64BIT "Turns on flags that produce 64 bit object code if any are required" ON)
 
-add_library(omantlr3 STATIC ${ANTLR_SOURCES})
+include(CheckFunctionExists)
+include(CheckIncludeFiles)
+include(CheckIncludeFile)
+include(CheckTypeSize)
+
+
+macro(check_functions_exist_and_define func_names)
+  foreach(func_name ${func_names})
+    string(TOUPPER ${func_name} DEFINE_SUFFIX)
+    check_function_exists(${func_name} HAVE_${DEFINE_SUFFIX})
+    # message(STATUS "************* ${func_name} ${HAVE_${DEFINE_SUFFIX}} ")
+  endforeach()
+endmacro(check_functions_exist_and_define)
+
+macro(check_headers_exist_and_define header_names)
+  foreach(header_name ${header_names})
+    string(TOUPPER ${header_name} DEFINE_SUFFIX)
+    string(REPLACE "." "_" DEFINE_SUFFIX ${DEFINE_SUFFIX})
+    string(REPLACE "/" "_" DEFINE_SUFFIX ${DEFINE_SUFFIX})
+    check_include_file(${header_name} HAVE_${DEFINE_SUFFIX})
+    # message(STATUS "************* ${header_name} ${HAVE_${DEFINE_SUFFIX}} ")
+  endforeach()
+endmacro(check_headers_exist_and_define)
+
+
+set(FUNCS_TO_CHECK accept memmove memset strdup)
+# The quote is needed here to evaluate
+check_functions_exist_and_define("${FUNCS_TO_CHECK}")
+
+
+set(HEADERS_TO_CHECK arpa/nameser.h ctype.h dlfcn.h inttypes.h malloc.h memory.h 
+                     netdb.h netinet/in.h netinet/tcp.h resolv.h socket.h
+                     stdarg.h stdint.h stdlib.h strings.h string.h sys/malloc.h
+                     sys/socket.h sys/stat.h sys/types.h unistd.h)
+# The quote is needed here to evaluate
+check_headers_exist_and_define("${HEADERS_TO_CHECK}")
+
+check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
+
+# We use this just to get the define. It will check existence as well
+# and sets HAVE_INTPTR_T
+check_type_size(intptr_t INTPTR_T)
+
+# Generate a configure header
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/antlr3config.h.in.cmake ${CMAKE_CURRENT_SOURCE_DIR}/include/antlr3config.h)
+
+
+
+add_library(omantlr3 STATIC)
+
+target_sources(omantlr3 PRIVATE ${ANTLR_SOURCES})
 target_include_directories(omantlr3 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-# for antlr3config.h. Needs to be removed after fixing where the file is generated. i.e., move to ./include folder
-target_include_directories(omantlr3 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
-target_compile_definitions(omantlr3 PRIVATE ANTLR3_NODEBUGGER
-                                            #ANTLR3_USE_64BIT #apparently this is already done by a header file in ./include
-                                            )

--- a/antlr/3.2/libantlr3c-3.2/antlr3config.h.in.cmake
+++ b/antlr/3.2/libantlr3c-3.2/antlr3config.h.in.cmake
@@ -1,0 +1,179 @@
+#define ANTLR_C_VERSION_3_2
+
+/* Define if ANTLR debugger not required */
+#cmakedefine ANTLR3_NODEBUGGER 1
+
+/* Define if 64 bit mode required */
+#cmakedefine ANTLR3_USE_64BIT 1
+
+/* Define to 1 if you have the `accept' function. */
+#cmakedefine HAVE_ACCEPT 1
+
+/* Define to 1 if you have the <arpa/nameser.h> header file. */
+#cmakedefine HAVE_ARPA_NAMESER_H 1
+
+/* Define to 1 if you have the <ctype.h> header file. */
+#cmakedefine HAVE_CTYPE_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* Define to 1 if the system has the type `intptr_t'. */
+#cmakedefine HAVE_INTPTR_T 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <malloc.h> header file. */
+#cmakedefine HAVE_MALLOC_H 1
+
+/* Define to 1 if you have the `memmove' function. */
+#cmakedefine HAVE_MEMMOVE 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#cmakedefine HAVE_MEMSET 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#cmakedefine HAVE_NETDB_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#cmakedefine HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+#cmakedefine HAVE_NETINET_TCP_H 1
+
+/* Define to 1 if you have the <resolv.h> header file. */
+#cmakedefine HAVE_RESOLV_H 1
+
+/* Define to 1 if you have the <socket.h> header file. */
+#cmakedefine HAVE_SOCKET_H 1
+
+/* Define to 1 if you have the <stdarg.h> header file. */
+#cmakedefine HAVE_STDARG_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strdup' function. */
+#cmakedefine HAVE_STRDUP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/malloc.h> header file. */
+#cmakedefine HAVE_SYS_MALLOC_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#cmakedefine HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if the system has the type `uintptr_t'. */
+#cmakedefine HAVE_UINTPTR_T 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Name of package */
+#define PACKAGE "libantlr3c"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "jimi@temporal-wave.com"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libantlr3c"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libantlr3c 3.2"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libantlr3c"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "3.2"
+
+/* Define to 1 if you have the ANSI C header files. */
+#cmakedefine STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "3.2"
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+#cmakedefine _UINT32_T
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+#cmakedefine _UINT64_T
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+#cmakedefine _UINT8_T
+
+/* Define to empty if `const' does not conform to ANSI C. */
+#cmakedefine const
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#cmakedefine inline
+#endif
+
+/* Define to the type of a signed integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine int16_t
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine int32_t
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine int64_t
+
+/* Define to the type of a signed integer type of width exactly 8 bits if such
+   a type exists and the standard includes do not define it. */
+#cmakedefine int8_t
+
+/* Define to the type of a signed integer type wide enough to hold a pointer,
+   if such a type exists, and if the system does not define it. */
+#cmakedefine intptr_t
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#cmakedefine size_t
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine uint16_t
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine uint32_t
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine uint64_t
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+#cmakedefine uint8_t
+
+/* Define to the type of an unsigned integer type wide enough to hold a
+   pointer, if such a type exists, and if the system does not define it. */
+#cmakedefine uintptr_t


### PR DESCRIPTION

@mahge
Improve cmake support of antlr3.
375a2c4

  - Do a proper check of all the required headers and sub-standard functions
   needed.
  - Define the corresponding HAVE_* variables.
  - Generate an atlr3config.h header from cmake (corresponding to the
    auto conf one.)

      Note the antlr3config.h from cmake is generated in the include/
      directory.

@mahge
Workaround for FMIL's unusual structure.
ef6cc71

  - We now collect all the public include files of FMIL into one top
    level include folder. The structure of this folder matches the
    'installed' include folders of FMIL. We make ONLY this include dir
    for our libraries that depend on FMIL.

  - Shared builds of fmilib are disabled now (only for the new CMake build. Normal compilation is not affected). You can enable them if you really need them.

