### PR TITLE
Make building lp_solve optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,10 @@ add_library(omc::3rd::libzmq ALIAS libzmq-static)
 
 
 # lpsolve55
-omc_add_subdirectory(lpsolve)
-add_library(omc::3rd::lpsolve55 ALIAS lpsolve55)
+if(OMC_USE_LPSOLVE AND OMC_BUILD_LPSOLVE)
+  omc_add_subdirectory(lpsolve)
+  add_library(omc::3rd::lpsolve55 ALIAS lpsolve55)
+endif()
 
 
 


### PR DESCRIPTION
  - lp_solve needs bison and flex. These are not available in our
    build-dep packages or docker files we distribute. So make this optional
    for now.