### PR TITLE
Disable sundials's check of usability of suitsparse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ target_include_directories(omcgc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/gc/include)
 # to be set explicitly for use of pthreads API on Windows.
 if(MINGW)
     target_compile_definitions(omcgc PUBLIC GC_WIN32_PTHREADS)
-else(MINGW)
+else()
     target_compile_definitions(omcgc PUBLIC GC_THREADS)
 endif(MINGW)
 
@@ -150,11 +150,31 @@ add_library(omc::3rd::modelica_io ALIAS ModelicaIO)
 
 # SuiteSparse
 omc_add_subdirectory(SuiteSparse-5.8.1)
-add_library(omc::3rd::suitesparse::klu ALIAS klu)
-target_include_directories(klu INTERFACE SuiteSparse/KLU/Include)
+# add_library(omc::3rd::suitesparse::klu ALIAS klu)
+target_include_directories(klu INTERFACE SuiteSparse-5.8.1/KLU/Include)
+target_include_directories(amd INTERFACE SuiteSparse-5.8.1/AMD/Include)
+target_include_directories(colamd INTERFACE SuiteSparse-5.8.1/COLAMD/Include)
+target_include_directories(btf INTERFACE SuiteSparse-5.8.1/BTF/Include)
+target_include_directories(suitesparseconfig INTERFACE SuiteSparse-5.8.1/SuiteSparse_config/)
+
 
 # sundials
+set(KLU_LIBRARY klu)
+set(AMD_LIBRARY amd)
+set(COLAMD_LIBRARY colamd)
+set(BTF_LIBRARY btf)
+set(SUITESPARSECONFIG_LIBRARY suitesparseconfig)
+
+option(SUNDIALS_KLU_ENABLE "Enable KLU support" ON)
 option(SUNDIALS_EXAMPLES_ENABLE_C "Build SUNDIALS C examples" OFF)
 omc_add_subdirectory(sundials-5.4.0)
+
+# target_include_directories(sundials_cvode_static INTERFACE sundials-5.4.0/include)
+# # The sundials_config.h files are generated in the build directory. Add it as an include dir.
+# target_include_directories(sundials_cvode_static INTERFACE ${sundials_BINARY_DIR}/include/)
+# add_library(omc::3rd::sundials::cvode::static ALIAS sundials_cvode_static)
+
+# target_link_libraries(sundials_sunlinsolklu_static INTERFACE omc::3rd::suitesparse::klu)
+# add_library(omc::3rd::sundials::cvode::static ALIAS sundials_sunlinsolklu_static)
 
 

--- a/sundials-5.4.0/config/SundialsKLU.cmake
+++ b/sundials-5.4.0/config/SundialsKLU.cmake
@@ -27,47 +27,49 @@ set(KLU_FOUND FALSE)
 include(FindKLU)
 # If we have the KLU libraries, test them
 if(KLU_LIBRARIES)
-  message(STATUS "Looking for KLU libraries...")
-  # Create the KLUTest directory
-  set(KLUTest_DIR ${PROJECT_BINARY_DIR}/KLUTest)
-  file(MAKE_DIRECTORY ${KLUTest_DIR})
-  # Create a CMakeLists.txt file
-  file(WRITE ${KLUTest_DIR}/CMakeLists.txt
-    "CMAKE_MINIMUM_REQUIRED(VERSION 2.8)\n"
-    "PROJECT(ltest C)\n"
-    "SET(CMAKE_VERBOSE_MAKEFILE ON)\n"
-    "SET(CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\")\n"
-    "SET(CMAKE_C_COMPILER \"${CMAKE_C_COMPILER}\")\n"
-    "SET(CMAKE_C_FLAGS \"${CMAKE_C_FLAGS}\")\n"
-    "SET(CMAKE_C_FLAGS_RELEASE \"${CMAKE_C_FLAGS_RELEASE}\")\n"
-    "SET(CMAKE_C_FLAGS_DEBUG \"${CMAKE_C_FLAGS_DEBUG}\")\n"
-    "SET(CMAKE_C_FLAGS_RELWITHDEBUGINFO \"${CMAKE_C_FLAGS_RELWITHDEBUGINFO}\")\n"
-    "SET(CMAKE_C_FLAGS_MINSIZE \"${CMAKE_C_FLAGS_MINSIZE}\")\n"
-    "INCLUDE_DIRECTORIES(${KLU_INCLUDE_DIR})\n"
-    "ADD_EXECUTABLE(ltest ltest.c)\n"
-    "TARGET_LINK_LIBRARIES(ltest ${KLU_LIBRARIES})\n")
-# Create a C source file which calls a KLU function
-# SGS TODO what is a simple KLU method to invoke?
-  file(WRITE ${KLUTest_DIR}/ltest.c
-    "\#include \"klu.h\"\n"
-    "int main(){\n"
-    "klu_common Common;\n"
-    "klu_defaults (&Common);\n"
-    "return(0);\n"
-    "}\n")
-  # Attempt to link the "ltest" executable
-  try_compile(LTEST_OK ${KLUTest_DIR} ${KLUTest_DIR} ltest OUTPUT_VARIABLE MY_OUTPUT)
-
-  # To ensure we do not use stuff from the previous attempts,
-  # we must remove the CMakeFiles directory.
-  file(REMOVE_RECURSE ${KLUTest_DIR}/CMakeFiles)
-  # Process test result
-  if(LTEST_OK)
-    message(STATUS "Checking if KLU works... OK")
     set(KLU_FOUND TRUE)
-  else(LTEST_OK)
-    message(STATUS "Checking if KLU works... FAILED")
-  endif(LTEST_OK)
+
+#   message(STATUS "Looking for KLU libraries...")
+#   # Create the KLUTest directory
+#   set(KLUTest_DIR ${PROJECT_BINARY_DIR}/KLUTest)
+#   file(MAKE_DIRECTORY ${KLUTest_DIR})
+#   # Create a CMakeLists.txt file
+#   file(WRITE ${KLUTest_DIR}/CMakeLists.txt
+#     "CMAKE_MINIMUM_REQUIRED(VERSION 2.8)\n"
+#     "PROJECT(ltest C)\n"
+#     "SET(CMAKE_VERBOSE_MAKEFILE ON)\n"
+#     "SET(CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\")\n"
+#     "SET(CMAKE_C_COMPILER \"${CMAKE_C_COMPILER}\")\n"
+#     "SET(CMAKE_C_FLAGS \"${CMAKE_C_FLAGS}\")\n"
+#     "SET(CMAKE_C_FLAGS_RELEASE \"${CMAKE_C_FLAGS_RELEASE}\")\n"
+#     "SET(CMAKE_C_FLAGS_DEBUG \"${CMAKE_C_FLAGS_DEBUG}\")\n"
+#     "SET(CMAKE_C_FLAGS_RELWITHDEBUGINFO \"${CMAKE_C_FLAGS_RELWITHDEBUGINFO}\")\n"
+#     "SET(CMAKE_C_FLAGS_MINSIZE \"${CMAKE_C_FLAGS_MINSIZE}\")\n"
+#     "INCLUDE_DIRECTORIES(${KLU_INCLUDE_DIR})\n"
+#     "ADD_EXECUTABLE(ltest ltest.c)\n"
+#     "TARGET_LINK_LIBRARIES(ltest ${KLU_LIBRARIES})\n")
+# # Create a C source file which calls a KLU function
+# # SGS TODO what is a simple KLU method to invoke?
+#   file(WRITE ${KLUTest_DIR}/ltest.c
+#     "\#include \"klu.h\"\n"
+#     "int main(){\n"
+#     "klu_common Common;\n"
+#     "klu_defaults (&Common);\n"
+#     "return(0);\n"
+#     "}\n")
+#   # Attempt to link the "ltest" executable
+#   try_compile(LTEST_OK ${KLUTest_DIR} ${KLUTest_DIR} ltest OUTPUT_VARIABLE MY_OUTPUT)
+
+#   # To ensure we do not use stuff from the previous attempts,
+#   # we must remove the CMakeFiles directory.
+#   file(REMOVE_RECURSE ${KLUTest_DIR}/CMakeFiles)
+#   # Process test result
+#   if(LTEST_OK)
+#     message(STATUS "Checking if KLU works... OK")
+#     set(KLU_FOUND TRUE)
+#   else(LTEST_OK)
+#     message(STATUS "Checking if KLU works... FAILED")
+#   endif(LTEST_OK)
 else(KLU_LIBRARIES)
   print_error("KLU LIBRARIES NOT Found. Please check library path" "${SUNDIALS_KLU_LIBRARY_DIR} ")
   message(STATUS "Looking for KLU libraries... FAILED")


### PR DESCRIPTION
  - There is no need to check if a small file that just includes suitsparse
    can be compiled. We have SuiteSparse in our sources. It will work.

    The problem with the check is that it expects SuiteSparse to be already
    built. We do not want that. It is intended to be used with installed
    or already pre-built SuiteSparse.

    For us, at configure time we just want to tell Sundials that we have
    SuiteSparse and we will build it. It should just assume it works.