### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ omc_add_subdirectory(FMIL)
 # We create a top level 'include' directory that matches their include structure when FMIL is installed-to-be-used.
 # This is how every library should be. That way when you install the library you just change the include
 # path and every include will be resolved as it was during build time.  Ideally it should even be in  'include/FMIL/'
-# but hat won't match how they install their files right now.
+# but that won't match how they install their files right now.
 file(MAKE_DIRECTORY ${FMILibrary_SOURCE_DIR}/include)
 # Do not ask me why the fmilib.h is in the cmake.config directory.
 file(COPY ${FMILibrary_SOURCE_DIR}/Config.cmake/fmilib.h DESTINATION ${FMILibrary_SOURCE_DIR}/include)
@@ -42,7 +42,6 @@ file(COPY ${FMILibrary_SOURCE_DIR}/src/Import/include/FMI DESTINATION ${FMILibra
 file(COPY ${FMILibrary_SOURCE_DIR}/src/Import/include/FMI1 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
 file(COPY ${FMILibrary_SOURCE_DIR}/src/Import/include/FMI2 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
 
-# This files
 file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/FMI DESTINATION ${FMILibrary_SOURCE_DIR}/include)
 file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/FMI1 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
 file(COPY ${FMILibrary_SOURCE_DIR}/src/Util/include/FMI2 DESTINATION ${FMILibrary_SOURCE_DIR}/include)
@@ -183,6 +182,8 @@ set(COLAMD_LIBRARY colamd)
 set(BTF_LIBRARY btf)
 set(SUITESPARSECONFIG_LIBRARY suitesparseconfig)
 
+option(SUNDIALS_BUILD_STATIC_LIBS "Build static libraries" ON)
+option(SUNDIALS_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(SUNDIALS_KLU_ENABLE "Enable KLU support" ON)
 option(SUNDIALS_EXAMPLES_ENABLE_C "Build SUNDIALS C examples" OFF)
 option(SUNDIALS_LAPACK_ENABLE "Enable Lapack support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,62 @@ add_library(omc::3rd::sundials::cvode::static ALIAS sundials_cvode_static)
 # target_link_libraries(sundials_sunlinsolklu_static INTERFACE omc::3rd::suitesparse::klu)
 # add_library(omc::3rd::sundials::cvode::static ALIAS sundials_sunlinsolklu_static)
 
+
+
 # Ipopt
 omc_add_subdirectory(Ipopt-3.13.4)
+## Just like FMIL, Ipopt assumes it will be always installed before use. So it does not organize
+## its header files properly. We deal with that here.
+## We collect all public headers to a new include dir in the build directory of Ipopt.
+
+set(IPOPT_LINALG_HDRS ${IpOpt_SOURCE_DIR}/src/LinAlg/IpMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpSymMatrix.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpExpansionMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpVector.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpDenseVector.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpCompoundVector.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpCompoundMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpCompoundSymMatrix.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpSumSymMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpDiagMatrix.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpIdentityMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpScaledMatrix.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpSymScaledMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpZeroSymMatrix.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/IpBlas.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/IpLapack.hpp)
+
+set(IPOPT_TMATRICES_HDRS ${IpOpt_SOURCE_DIR}/src/LinAlg/TMatrices/IpGenTMatrix.hpp
+        ${IpOpt_SOURCE_DIR}/src/LinAlg/TMatrices/IpSymTMatrix.hpp ${IpOpt_SOURCE_DIR}/src/LinAlg/TMatrices/IpTripletHelper.hpp)
+
+set(IPOPT_INTERFACES_HDRS ${IpOpt_SOURCE_DIR}/src/Interfaces/IpAlgTypes.hpp
+        ${IpOpt_SOURCE_DIR}/src/Interfaces/IpIpoptApplication.hpp ${IpOpt_SOURCE_DIR}/src/Interfaces/IpNLP.hpp
+        ${IpOpt_SOURCE_DIR}/src/Interfaces/IpReturnCodes.h ${IpOpt_SOURCE_DIR}/src/Interfaces/IpReturnCodes.hpp
+        ${IpOpt_SOURCE_DIR}/src/Interfaces/IpReturnCodes_inc.h ${IpOpt_SOURCE_DIR}/src/Interfaces/IpReturnCodes.inc
+        ${IpOpt_SOURCE_DIR}/src/Interfaces/IpSolveStatistics.hpp ${IpOpt_SOURCE_DIR}/src/Interfaces/IpStdCInterface.h
+        ${IpOpt_SOURCE_DIR}/src/Interfaces/IpTNLP.hpp ${IpOpt_SOURCE_DIR}/src/Interfaces/IpTNLPAdapter.hpp
+        ${IpOpt_SOURCE_DIR}/src/Interfaces/IpTNLPReducer.hpp)
+
+set(IPOPT_COMMON_HDRS ${IpOpt_SOURCE_DIR}/src/Common/IpCachedResults.hpp
+        ${IpOpt_SOURCE_DIR}/src/Common/IpDebug.hpp ${IpOpt_SOURCE_DIR}/src/Common/IpException.hpp
+        ${IpOpt_SOURCE_DIR}/src/Common/IpJournalist.hpp ${IpOpt_SOURCE_DIR}/src/Common/IpObserver.hpp
+        ${IpOpt_SOURCE_DIR}/src/Common/IpOptionsList.hpp ${IpOpt_SOURCE_DIR}/src/Common/IpoptConfig.h
+        ${IpOpt_SOURCE_DIR}/src/Common/config_ipopt_default.h ${IpOpt_SOURCE_DIR}/src/Common/IpReferenced.hpp
+        ${IpOpt_SOURCE_DIR}/src/Common/IpRegOptions.hpp ${IpOpt_SOURCE_DIR}/src/Common/IpSmartPtr.hpp
+        ${IpOpt_SOURCE_DIR}/src/Common/IpTaggedObject.hpp ${IpOpt_SOURCE_DIR}/src/Common/IpTimedTask.hpp
+        ${IpOpt_SOURCE_DIR}/src/Common/IpTypes.hpp ${IpOpt_SOURCE_DIR}/src/Common/IpUtils.hpp)
+
+set(IPOPT_ALGORITHMS_HDRS ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIpoptCalculatedQuantities.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIpoptData.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIteratesVector.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpTimingStatistics.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIpoptNLP.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpOrigIpoptNLP.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpNLPScaling.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpAlgBuilder.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIpoptAlg.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpAlgStrategy.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpSearchDirCalculator.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpLineSearch.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpMuUpdate.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpConvCheck.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIterateInitializer.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpIterationOutput.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpHessianUpdater.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpEqMultCalculator.hpp ${IpOpt_SOURCE_DIR}/src/Algorithm/IpAugSystemSolver.hpp
+        ${IpOpt_SOURCE_DIR}/src/Algorithm/IpPDSystemSolver.hpp)
+set(IPOPT_LINEARSOLVERS_HDRS ${IpOpt_SOURCE_DIR}/src/Algorithm/LinearSolvers/IpSymLinearSolver.hpp)
+
+set(IPOPT_ALL_HDRS ${IPOPT_LINALG_HDRS} ${IPOPT_TMATRICES_HDRS} ${IPOPT_INTERFACES_HDRS}
+                   ${IPOPT_COMMON_HDRS} ${IPOPT_ALGORITHMS_HDRS} ${IPOPT_LINEARSOLVERS_HDRS})
+
+file(MAKE_DIRECTORY ${IpOpt_BINARY_DIR}/include/Ipopt)
+file(COPY ${IPOPT_ALL_HDRS} DESTINATION ${IpOpt_BINARY_DIR}/include/Ipopt)
+
+# We give this new directory as include dir ONLY for targets that depend on Ipopt (not Ipopt itslef).
+target_include_directories(ipopt INTERFACE ${IpOpt_BINARY_DIR}/include/)
 add_library(omc::3rd::ipopt ALIAS ipopt)

--- a/lis-1.4.12/src/CMakeLists.txt
+++ b/lis-1.4.12/src/CMakeLists.txt
@@ -17,3 +17,5 @@ target_sources(lis PRIVATE ${LIS_MATRIX_SOURCES} ${LIS_VECTOR_SOURCES} ${LIS_MAT
 target_compile_definitions(lis PRIVATE HAVE_CONFIG_H)
 
 target_include_directories(lis PUBLIC ${Lis_SOURCE_DIR}/include)
+
+install(TARGETS lis)


### PR DESCRIPTION
@mahge
[cmake] Disable sundials shared libs. …
60b590c
  - Note! This does not affect the normal OpenModelica makefile build
    process. This is just for the new CMake config and build.

  - They are not needed per se. It is a waste to build both shared and
    static versions at the same time.

@mahge
[cmake] Install liblis. …
4706572
  - Probably not needed. But the makefiles build system installs it so
    we do it for now.

@mahge
[cmake] Handle Ipopt's public headers. …
10645db
  - Just like FMIL, Ipopt assumes it will be always installed before use.
    So it does not organize its header files properly.

    We collect all public headers to a new include dir in the build directory
    of Ipopt. Then we provide this new directory as include dir for targets
    that depend on Ipopt.