### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,13 @@ project(OMCompiler_3rdParty)
 omc_add_subdirectory(antlr)
 add_library(omc::3rd::omantlr3 ALIAS omantlr3)
 
-
+# CDaskr
+omc_add_subdirectory(Cdaskr)
+add_library(omc::3rd::cdaskr ALIAS cdaskr)
 
 # CMinpack
 omc_add_subdirectory(CMinpack)
 add_library(omc::3rd::cminpack ALIAS cminpack)
-
 
 
 # # cppzmq

--- a/Cdaskr/CMakeLists.txt
+++ b/Cdaskr/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+cmake_minimum_required(VERSION 3.14)
+project(Cdaskr)
+
+
+set(OM_CDASKR_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/solver/daux.c
+                      ${CMAKE_CURRENT_SOURCE_DIR}/solver/ddaskr.c
+                      ${CMAKE_CURRENT_SOURCE_DIR}/solver/dlinpk.c)
+
+add_library(cdaskr STATIC)
+target_sources(cdaskr PRIVATE ${OM_CDASKR_SOURCES})
+
+install(TARGETS cdaskr)

--- a/Ipopt-3.13.4/ThirdParty/MUMPS/CMakeLists.txt
+++ b/Ipopt-3.13.4/ThirdParty/MUMPS/CMakeLists.txt
@@ -128,6 +128,13 @@ else()
   add_library(coinmumps STATIC ${MUMPS_D_SRCS} ${MUMPS_COMMON_SRCS} ${MUMPS_LIBSEQ_SRCS})
 endif()
 
+## Add fallow-argument-mismatch for newer Fortran compiler versions.
+include(CheckFortranCompilerFlag)
+check_fortran_compiler_flag(-fallow-argument-mismatch NEEDS_FALLOW_ARG_MISMATCH)
+if(NEEDS_FALLOW_ARG_MISMATCH)
+  target_compile_options(coinmumps PRIVATE -fallow-argument-mismatch)
+endif()
+
 if (MSVC)
   target_compile_definitions(coinmumps PRIVATE "/DMUMPS_ARITH=MUMPS_ARITH_d")
 else ()


### PR DESCRIPTION
@mahge
Allow argument mismatch for MUMPS fortran code. …
53e51da
  - This is needed for newer Fortran versions.
  - For the autoconf build system of OpenModelica we passed this from
    the Makefiles using FFLAGS.

@mahge
[cmake] Add CMake config support for Cdaskr.
c26daa3