### PR TITLE
Use zlib from ModelicaExternalC.

### DIFF
--- a/FMIL/CMakeLists.txt
+++ b/FMIL/CMakeLists.txt
@@ -231,7 +231,7 @@ configure_file (
   "${FMILibrary_BINARY_DIR}/fmilib_config.h"
   )
 
-set(FMILIB_SHARED_SUBLIBS ${FMIXML_LIBRARIES} ${FMIZIP_LIBRARIES} ${FMICAPI_LIBRARIES} expat minizip zlib c99snprintf)
+set(FMILIB_SHARED_SUBLIBS ${FMIXML_LIBRARIES} ${FMIZIP_LIBRARIES} ${FMICAPI_LIBRARIES} expat minizip c99snprintf)
 set(FMILIB_SUBLIBS ${FMIIMPORT_LIBRARIES} ${JMUTIL_LIBRARIES} ${FMILIB_SHARED_SUBLIBS})
 set(FMILIB_SHARED_SRC ${FMIIMPORTSOURCE} ${JMUTILSOURCE} ${FMIIMPORTHEADERS})
 
@@ -246,7 +246,7 @@ if(FMILIB_GENERATE_BUILD_STAMP)
 		DEPENDS ${FMILIB_SUBLIBS}
 	)
 	add_library(fmilib_timestamp STATIC ${FMILibrary_BINARY_DIR}/config_fmilib.c "${FMILibrary_BINARY_DIR}/fmilib_config.h")
-#	add_dependencies(fmilib_timestamp ${FMILIB_SUBLIBS} expat minizip zlib ${FMILIBRARYHOME}/Config.cmake/config_stamp.cmake)
+#	add_dependencies(fmilib_timestamp ${FMILIB_SUBLIBS} expat minizip ${OMC_ZLIB_LIBRARY} ${FMILIBRARYHOME}/Config.cmake/config_stamp.cmake)
 
 	set(FMILIB_SUBLIBS ${FMILIB_SUBLIBS} fmilib_timestamp)
 	set(FMILIB_SHARED_SRC ${FMILIB_SHARED_SRC} ${FMILibrary_BINARY_DIR}/config_fmilib.c)

--- a/FMIL/Config.cmake/Minizip/CMakeLists.txt
+++ b/FMIL/Config.cmake/Minizip/CMakeLists.txt
@@ -8,11 +8,11 @@ set(SKIP_INSTALL_FILES ON)
 if(NOT FMILIB_INSTALL_SUBLIBS)
 	set(SKIP_INSTALL_LIBRARIES ON)
 endif()
-add_subdirectory("${FMILIB_THIRDPARTYLIBS}/Zlib/zlib-1.2.6" "${FMILibrary_BINARY_DIR}/zlib")
+# add_subdirectory("${FMILIB_THIRDPARTYLIBS}/Zlib/zlib-1.2.6" "${FMILibrary_BINARY_DIR}/zlib")
 
-if(CMAKE_CL_64)
-	set_target_properties(zlib PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
-endif()
+# if(CMAKE_CL_64)
+# 	set_target_properties(zlib PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+# endif()
 
 if(CMAKE_HOST_APPLE)
 set(PLATFORM __APPLE__)
@@ -30,7 +30,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 endif()
 
-include_directories("${FMILIB_THIRDPARTYLIBS}/Zlib/zlib-1.2.6" "${FMILibrary_BINARY_DIR}/zlib")
+# include_directories("${FMILIB_THIRDPARTYLIBS}/Zlib/zlib-1.2.6" "${FMILibrary_BINARY_DIR}/zlib")
 set(SOURCE
   ${FMILIB_THIRDPARTYLIBS}/Minizip/minizip/ioapi.c
   ${FMILIB_THIRDPARTYLIBS}/Minizip/minizip/miniunz.c
@@ -58,7 +58,7 @@ endif(WIN32)
 
 add_library(minizip ${SOURCE} ${HEADERS})
 
-target_link_libraries(minizip zlib)
+target_link_libraries(minizip ${OMC_ZLIB_LIBRARY})
 
 if(FMILIB_INSTALL_SUBLIBS)
 	install(TARGETS minizip

--- a/FMIL/Config.cmake/fmizip.cmake
+++ b/FMIL/Config.cmake/fmizip.cmake
@@ -13,16 +13,16 @@
 
 if(NOT FMIZIPDIR)
     set(FMIZIPDIR ${FMILIBRARYHOME}/src/ZIP)
-	
+
     include(jmutil)
-	
+
 	# set(DOXYFILE_EXTRA_SOURCES "${DOXYFILE_EXTRA_SOURCES} \"${FMIZIPDIR}/include\"")
 
     set(FMIZIP_LIBRARIES fmizip)
-	
+
     add_subdirectory(Config.cmake/Minizip)
-	
-	include_directories("${FMIZIPDIR}/include" "${FMILIB_THIRDPARTYLIBS}/Minizip/minizip" "${FMILIB_THIRDPARTYLIBS}/FMI" "${FMILIB_THIRDPARTYLIBS}/Zlib/zlib-1.2.6" "${FMILibrary_BINARY_DIR}/zlib")
+
+	include_directories("${FMIZIPDIR}/include" "${FMILIB_THIRDPARTYLIBS}/Minizip/minizip" "${FMILIB_THIRDPARTYLIBS}/FMI")
 
 set(FMIZIPSOURCE
   ${FMIZIPDIR}/src/fmi_zip_unzip.c

--- a/ModelicaExternalC/CMakeLists.txt
+++ b/ModelicaExternalC/CMakeLists.txt
@@ -3,6 +3,25 @@ cmake_minimum_required(VERSION 3.14)
 project(OMModelicaExternalC)
 
 
+# zlib
+# We have decided to use zlib from here. We could have used the system zlib. However,
+# modelica annotations request for "zlib" while the system zlib is OFTEN (but not always) called "libz"
+# which means it should be used as "z". We can modify the annotations to use "z" but then
+# it will be the same issue on systems that call it "zlib". So we need to find a solution.
+# Originally I was creating a sym link to the system zlib in our lib directories. However,
+# that might be confusing for others. So it might be better to explicitly
+# build it and use it from here. The one advantage of this is that we can compile it with -fpic so
+# that we can link it into our static FMUs.
+file(GLOB libzlib_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/C-Sources/zlib/*.c)
+add_library(zlib STATIC ${libzlib_SOURCES})
+
+install(TARGETS zlib)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/C-Sources/zlib/zlib.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/C-Sources/zlib/zconf.h
+        TYPE INCLUDE)
+
+
+
 # ModelicaExternalC
 set(libModelicaExternalC_SOURCES C-Sources/ModelicaFFT.c
                                  C-Sources/ModelicaInternal.c
@@ -17,11 +36,14 @@ target_link_libraries(ModelicaExternalC PUBLIC m)
 set(libModelicaMatIO_SOURCES C-Sources/ModelicaMatIO.c C-Sources/snprintf.c)
 add_library(ModelicaMatIO STATIC ${libModelicaMatIO_SOURCES})
 
-find_package(ZLIB)
-if(ZLIB_FOUND)
-    target_link_libraries(ModelicaMatIO PUBLIC ZLIB::ZLIB)
-    target_compile_definitions(ModelicaMatIO PRIVATE HAVE_ZLIB)
-endif()
+target_compile_definitions(ModelicaMatIO PRIVATE HAVE_ZLIB)
+target_link_libraries(ModelicaMatIO PUBLIC zlib)
+
+# find_package(ZLIB)
+# if(ZLIB_FOUND)
+#     target_link_libraries(ModelicaMatIO PUBLIC ZLIB::ZLIB)
+#     target_compile_definitions(ModelicaMatIO PRIVATE HAVE_ZLIB)
+# endif()
 
 # find_package(HDF5)
 # if(HDF5_FOUND)
@@ -49,8 +71,6 @@ target_compile_definitions(ModelicaStandardTables PRIVATE -DDUMMY_FUNCTION_USERT
 
 target_link_libraries(ModelicaStandardTables INTERFACE ModelicaMatIO)
 target_link_libraries(ModelicaStandardTables PUBLIC m)
-
-
 
 
 install(TARGETS ModelicaExternalC


### PR DESCRIPTION
  - We have decided to use zlib from here. We could have used the system
    zlib. However, modelica annotations request for "zlib" while the system
    zlib is OFTEN (but not always) called "libz" which means it should be
    used as "z".
    We can modify the annotations to use "z" but then it will be the same
    issue on systems that call it "zlib". So we need to find a solution.

    Originally I was tried creating a sym link to the system zlib in our
    lib directories. However, that might be confusing for others. So it
    might be better to explicitly build it and use it from here.

    An added advantage of this is that we can compile it with -fpic so
    that we can link it into our static FMUs.