### PR TITLE
Add an alias for zlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_library(omc::3rd::Modelica::ExternalC ALIAS ModelicaExternalC)
 add_library(omc::3rd::Modelica::MatIO ALIAS ModelicaMatIO)
 add_library(omc::3rd::Modelica::IO ALIAS ModelicaIO)
 add_library(omc::3rd::Modelica::StandardTables ALIAS ModelicaStandardTables)
+add_library(omc::3rd::Modelica::zlib ALIAS zlib)
 
 
 omc_add_subdirectory(open62541)


### PR DESCRIPTION
  - Now that omc's dependency on ModelicaExternalC is removed, we do not
    link them in anymore.
    So zlib needs to be added itself to the linking. Previously it was
    linked transitively through ModelicaMatIO