### PR TITLE
Use winsock2.h instead of winsock.h

### DIFF
--- a/antlr/3.2/libantlr3c-3.2/include/antlr3defs.h
+++ b/antlr/3.2/libantlr3c-3.2/include/antlr3defs.h
@@ -107,8 +107,8 @@
 #endif
 
 #include    <windows.h>
-#include	<stdlib.h>
-#include	<winsock.h>
+#include    <stdlib.h>
+#include    <winsock2.h>
 #include    <stdio.h>
 #include    <sys/types.h>
 #include    <sys/stat.h>


### PR DESCRIPTION
  - These two can not used be simultaneously. The rest of our code (e.g. our
    parsers) use winsock2.h.

    winsock2.h is backwards compatible with winsock.h. Use it as we are
    not possibly targeting anything that does not have winsock2 support.

