### PR TITLE
Minor fixes for portability.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,15 +74,15 @@ option(enable_large_config "Optimize for large heap or root set" ON)
 omc_add_subdirectory(gc)
 target_include_directories(omcgc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/gc/include)
 # make sure every target that links to gc-lib has its sources
-# compiled with -DGC_WIN32_PTHREADS (for pthreads on Windows, i.e., our MingW)
+# compiled with -DGC_WIN32_PTHREADS (for pthreads on Windows, i.e., OMDev or MSVC)
 # Or -DGC_THREADS (for auto detection on other systems.)
-# On Windows with MinGW OM uses pthreads-win32. GC_WIN32_PTHREADS is required
+# Even on Windows OM uses pthreads. GC_WIN32_PTHREADS is required
 # to be set explicitly for use of pthreads API on Windows.
-if(MINGW)
+if(WIN32)
     target_compile_definitions(omcgc PUBLIC GC_WIN32_PTHREADS)
 else()
     target_compile_definitions(omcgc PUBLIC GC_THREADS)
-endif(MINGW)
+endif()
 
 # Finally add an alias for clarity purposes.
 add_library(omc::3rd::omcgc ALIAS omcgc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,10 @@ option(SUNDIALS_BUILD_STATIC_LIBS "Build static libraries" ON)
 option(SUNDIALS_BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(SUNDIALS_KLU_ENABLE "Enable KLU support" ON)
 option(SUNDIALS_EXAMPLES_ENABLE_C "Build SUNDIALS C examples" OFF)
-option(SUNDIALS_LAPACK_ENABLE "Enable Lapack support" ON)
+
+if(OM_OMC_ENABLE_FORTRAN)
+  option(SUNDIALS_LAPACK_ENABLE "Enable Lapack support" ON)
+endif()
 
 omc_add_subdirectory(sundials-5.4.0)
 

--- a/FMIL/Config.cmake/Minizip/CMakeLists.txt
+++ b/FMIL/Config.cmake/Minizip/CMakeLists.txt
@@ -58,8 +58,12 @@ endif(WIN32)
 
 add_library(minizip ${SOURCE} ${HEADERS})
 
-target_link_libraries(minizip ${OMC_ZLIB_LIBRARY})
-target_include_directories(minizip PUBLIC ${OMC_ZLIB_INCLUDE_DIR})
+if(OPENMODELICA_NEW_CMAKE_BUILD)
+  target_link_libraries(minizip zlib)
+else()
+  target_link_libraries(minizip ${OMC_ZLIB_LIBRARY})
+  target_include_directories(minizip PUBLIC ${OMC_ZLIB_INCLUDE_DIR})
+endif()
 
 if(FMILIB_INSTALL_SUBLIBS)
 	install(TARGETS minizip

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -113,11 +113,17 @@ string(TOLOWER ${_HOST} HOST)
 message(STATUS "TARGET = ${HOST}")
 
 if (enable_threads)
-  find_package(Threads REQUIRED)
+  if(MSVC)
+    find_package(pthreads REQUIRED)
+    set(THREADDLLIBS PThreads4W::PThreads4W)
+  else()
+    find_package(Threads REQUIRED)
+    set(THREADDLLIBS ${CMAKE_THREAD_LIBS_INIT})
+  endif()
+
   message(STATUS "Thread library: ${CMAKE_THREAD_LIBS_INIT}")
   include_directories(libatomic_ops/src)
   include_directories(${Threads_INCLUDE_DIR})
-  set(THREADDLLIBS ${CMAKE_THREAD_LIBS_INIT})
   if (NOT (APPLE OR CYGWIN OR MSYS OR WIN32 OR HOST MATCHES mips-.*-irix6.*))
     set(THREADDLLIBS ${THREADDLLIBS} -ldl)
                                 # The predefined CMAKE_DL_LIBS may be broken.
@@ -130,8 +136,12 @@ if (CMAKE_USE_PTHREADS_INIT)
   if (HOST MATCHES .*-.*-hpux10.*)
     message(FATAL_ERROR "HP/UX 10 POSIX threads are not supported.")
   endif()
-  # Assume the compiler supports C11 (GCC) atomic intrinsics.
-  add_definitions("-DGC_BUILTIN_ATOMIC")
+
+  if(NOT MSVC)
+    # Assume the compiler supports C11 (GCC) atomic intrinsics.
+    add_definitions("-DGC_BUILTIN_ATOMIC")
+  endif()
+
   # Common defines for POSIX platforms.
   add_definitions("-DGC_THREADS -D_REENTRANT")
   if (enable_parallel_mark)
@@ -149,7 +159,7 @@ if (CMAKE_USE_PTHREADS_INIT)
     message("Only on NetBSD 2.0 or later.")
     add_definitions("-D_PTHREADS")
   endif()
-  if (ANDROID OR MSYS) # ANDROID variable is defined by CMake v3.7.0+.
+  if (ANDROID OR MSYS OR MINGW OR MSVC) # ANDROID variable is defined by CMake v3.7.0+.
     # Android NDK does not provide pthread_atfork.
   elseif (APPLE)
     if (enable_handle_fork AND NOT disable_handle_fork)
@@ -165,7 +175,7 @@ if (CMAKE_USE_PTHREADS_INIT)
   if (enable_sigrt_signals)
     add_definitions("-DGC_USESIGRT_SIGNALS")
   endif()
-  if (CYGWIN OR MSYS)
+  if (CYGWIN OR MSYS OR MINGW OR MSVC)
     set(SRC ${SRC} win32_threads.c)
   endif()
 elseif (CMAKE_USE_WIN32_THREADS_INIT)
@@ -420,7 +430,7 @@ endif()
 
 add_library(omcgc ${GC_LIBRARY_BUILD_TYPE} ${SRC})
 if (enable_threads)
-  target_link_libraries(omcgc PRIVATE ${THREADDLLIBS})
+  target_link_libraries(omcgc PUBLIC ${THREADDLLIBS})
 endif()
 
 if (enable_cplusplus)

--- a/libffi/include/ffi.h.in
+++ b/libffi/include/ffi.h.in
@@ -114,7 +114,7 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
+#if defined(_MSC_VER) && defined(FFI_BUILDING_DLL)
 # if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
 #  define FFI_API __declspec(dllexport)
 # elif !defined FFI_BUILDING  /* Importing libffi.DLL */

--- a/metis-5.1.0/GKlib/gk_arch.h
+++ b/metis-5.1.0/GKlib/gk_arch.h
@@ -31,7 +31,7 @@
 #endif
 
 
-#ifdef __MSC__ 
+#ifdef __MSC__
   #include "ms_stdint.h"
   #include "ms_inttypes.h"
   #include "ms_stat.h"
@@ -62,7 +62,7 @@ typedef ptrdiff_t ssize_t;
 
 #ifdef __MSC__
 /* MSC does not have rint() function */
-#define rint(x) ((int)((x)+0.5))  
+// #define rint(x) ((int)((x)+0.5))  // It does now.
 
 /* MSC does not have INFINITY defined */
 #ifndef INFINITY


### PR DESCRIPTION
[Improve GC compilation portability.](https://github.com/OpenModelica/OMCompiler-3rdParty/commit/4fec01680abc6346bf2b7b9d0c779cb007e11cde) 

  - Fix the configuration so that it can be compiled fine on MSVC. It needs
    special treatment since we want it to use PThreads on all platoforms
    including Windows with MSVC.

  - On Windows with MSVC it now expects to have the PThreads4W library.

  - Built-in atomic intrinsics are not available with MSVC. Make sure the
    configuration reflects that for MSVC.

  - Cover cases where it was only expecting MinGW on Windows and not MSVC.
@[mahge](https://github.com/OpenModelica/OMCompiler-3rdParty/commits?author=mahge)
mahge committed 4 hours ago
 
[Minor fixes for portability.](https://github.com/OpenModelica/OMCompiler-3rdParty/commit/a9c20f31d05977bf234042e5b36b8157213b746c) 

  - Sundails: Do not enable sundails Fortran if OpenModelica has disabled Fortran.

  - FMIL: Link to the correct zlib instance in FMIL's minizip compilation.

    For the autoconf based OpenModelica build the location of zlib library
    is passed through the variable OMC_ZLIB_LIBRARY.

    For the CMake based OpenModelica build this variable was empty and
    minizip was not actually linking to zlib. minizip is built as a static
    library so the linking has no impact in its own compilation excpet for
    the fact that it was including the system's zlib headers because those
    are the ones it finds first if it is not linked to our zlib (which
    transitively provides the headers).

  - LibFFi: Only add the dll direction markups if we are compiling it as
    a dll, i.e., FFI_BUILDING_DLL is defined.

  - Metis/GKLib: Remove conflicting definition rint(x). No need to define
    it since MSVC has it now.