### PR TITLE
Do not add -lpthread if clang.

### DIFF
--- a/gc/configure.ac
+++ b/gc/configure.ac
@@ -259,7 +259,11 @@ case "$THREADS" in
         if test "${enable_thread_local_alloc}" != no; then
           AC_DEFINE(THREAD_LOCAL_ALLOC)
         fi
-        THREADDLLIBS="-lpthread"
+        if test "$CC" != "clang"; then
+          THREADDLLIBS="-lpthread"
+        else
+          THREADDLLIBS=""
+        fi
         win32_threads=true
         ;;
       *-*-darwin*)


### PR DESCRIPTION
  - This was working fine for static version of `libomcgc` because it did
    not matter if the library was not found.
    However for the dynamic version `libtool` complains that it is not
    available and refuses to build the DLL on Windows.

    clang does not need (or even allow) `-lpthread` as it appears. So do not
    add it to the link command if we are using clang. If we are using gcc
    then it should be added.

