### PR TITLE
Fix compilation on OMDev/MinGW with CMake.

### DIFF
--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -289,7 +289,7 @@ if (enable_werror)
   endif()
 endif(enable_werror)
 
-if (enable_single_obj_compilation OR GC_BUILD_SHARED_LIBS)
+if (enable_single_obj_compilation)
   set(SRC extra/gc.c) # override SRC
   if (CMAKE_USE_PTHREADS_INIT)
     add_definitions("-DGC_PTHREAD_START_STANDALONE")

--- a/gc/include/gc_config_macros.h
+++ b/gc/include/gc_config_macros.h
@@ -178,7 +178,7 @@
 
 # if defined(__MINGW32__) || defined(__CEGCC__)
 #   if defined(GC_BUILD) || defined(__MINGW32_DELAY_LOAD__)
-#     define GC_API __declspec(dllexport)
+#     define GC_API extern __declspec(dllexport)
 #   else
 #     define GC_API __declspec(dllimport)
 #   endif


### PR DESCRIPTION
  - GC has a setting where it gets compiled as a single file (a file that
    includes all source files). According to the logs of the upstream GC
    repository this is done to enable more optimizations.
    It also enabled this one-file form when it was asked to build a shared
    library with CMake. Even if it was not asked for explicitly.

    However, the markup for the functions was missing the `extern` keyword
    which leads to some confusing duplicate declaration errors.

    Add the `extern` specifier. But **also disable the automatic one-file
    compilation for shared version** behavior since the autoconf build does
    not enable it unless it is asked for explicitly.

    We are trying to be consistent to avoid ANY surprises with this useful
    (I admit) but so very intrusive and infuriating library.
