### PR TITLE
[libffi] Fix config header preprocessor definition.

### DIFF
--- a/libffi/include/fficonfig_cmake.h.in
+++ b/libffi/include/fficonfig_cmake.h.in
@@ -18,7 +18,7 @@
 #cmakedefine FFI_DEBUG
 
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
-#cmakedefine FFI_EXEC_TRAMPOLINE_TABLE
+#cmakedefine01 FFI_EXEC_TRAMPOLINE_TABLE
 
 /* Define this if you want to enable pax emulated trampolines */
 #cmakedefine FFI_MMAP_EXEC_EMUTRAMP_PAX


### PR DESCRIPTION
  - The preprocessor variable FFI_EXEC_TRAMPOLINE_TABLE should be defined
    with a value. Either 0 or 1.

  - On almost all systems we supported so far this was undefined completely
    so it did not cause any issues.

  - With `macOS` on `aarch64` systems (like the M1 mac) libffi wants this to
    be "on". The CMake configuration was defining it to nothing, i.e.,

    ```c
    #define FFI_EXEC_TRAMPOLINE_TABLE
    ```

    and then compilation fails because the sources contain checks like

    ```c
    #if FFI_EXEC_TRAMPOLINE_TABLE
    ```
    which expect a value.

    Always define it either to 0 or 1. If it is to be "defined" it should
    be

    ```c
    #if FFI_EXEC_TRAMPOLINE_TABLE 1
    ```

    To be honest I am not sure if I completely understood how libffi wants
    to use this variable. But looking at the way their sources use this
    variable it seems like this is the right thing to do.

    I suspect the autoconf build also has this issue and should probably
    be fixed as well.

