### PR TITLE
Add -no-undefined to satisfy libtool on Windows.

### DIFF
--- a/lis-1.4.12/src/Makefile.am
+++ b/lis-1.4.12/src/Makefile.am
@@ -16,7 +16,7 @@ liblis@LIBSUFFIX@_la_LIBADD = matrix/libmatrix.la \
                    solver/libsolver.la \
                    esolver/libesolver.la \
                    system/libsystem.la \
-                   precision/libprecision.la 
+                   precision/libprecision.la
 if ENABLE_SAAMG
   liblis@LIBSUFFIX@_la_LIBADD += fortran/libfortran.la
   liblis@LIBSUFFIX@_la_LIBADD += fortran/amg/libsaamg.la
@@ -25,4 +25,5 @@ if ENABLE_FORTRAN
   liblis@LIBSUFFIX@_la_LIBADD += fortran/libfortran.la
 endif
 endif
-liblis@LIBSUFFIX@_la_SOURCES = 
+liblis@LIBSUFFIX@_la_SOURCES =
+liblis@LIBSUFFIX@_la_LDFLAGS = -no-undefined

--- a/lis-1.4.12/src/Makefile.in
+++ b/lis-1.4.12/src/Makefile.in
@@ -312,7 +312,8 @@ liblis@LIBSUFFIX@_la_LIBADD = matrix/libmatrix.la vector/libvector.la \
 	matvec/libmatvec.la precon/libprecon.la solver/libsolver.la \
 	esolver/libesolver.la system/libsystem.la \
 	precision/libprecision.la $(am__append_3) $(am__append_4)
-liblis@LIBSUFFIX@_la_SOURCES = 
+liblis@LIBSUFFIX@_la_SOURCES =
+liblis@LIBSUFFIX@_la_LDFLAGS = -no-undefined
 all: all-recursive
 
 .SUFFIXES:
@@ -378,8 +379,8 @@ clean-libLTLIBRARIES:
 	  echo "rm -f \"$${dir}/so_locations\""; \
 	  rm -f "$${dir}/so_locations"; \
 	done
-liblis@LIBSUFFIX@.la: $(liblis@LIBSUFFIX@_la_OBJECTS) $(liblis@LIBSUFFIX@_la_DEPENDENCIES) $(EXTRA_liblis@LIBSUFFIX@_la_DEPENDENCIES) 
-	$(LINK) -rpath $(libdir) $(liblis@LIBSUFFIX@_la_OBJECTS) $(liblis@LIBSUFFIX@_la_LIBADD) $(LIBS)
+liblis@LIBSUFFIX@.la: $(liblis@LIBSUFFIX@_la_OBJECTS) $(liblis@LIBSUFFIX@_la_DEPENDENCIES) $(EXTRA_liblis@LIBSUFFIX@_la_DEPENDENCIES)
+	$(LINK) -rpath $(libdir) $(liblis@LIBSUFFIX@_la_LDFLAGS) $(liblis@LIBSUFFIX@_la_OBJECTS) $(liblis@LIBSUFFIX@_la_LIBADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)


### PR DESCRIPTION
  - It refuses to build a shared library on Windows if this option is not set.
  - This was never an issue for us because we were using `lis` from MinGW itself (`pacman` managed). We only used the 3rdParty version when building on Linux.
   Now we want to switch to building from source because recent versions of mingw64-lis require MPI support and we do not want that. 
