### PR TITLE
Let CMake decide what to use for pthread

### DIFF
--- a/Ipopt-3.13.4/ThirdParty/MUMPS/CMakeLists.txt
+++ b/Ipopt-3.13.4/ThirdParty/MUMPS/CMakeLists.txt
@@ -143,7 +143,7 @@ endif ()
 target_link_libraries(coinmumps PUBLIC ${LAPACK_LIBRARIES})
 
 if(THREADS_HAVE_PTHREAD_ARG)
-  target_compile_options(coinmumps PUBLIC pthread)
+  target_compile_options(coinmumps PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 endif()
 if(CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(coinmumps PUBLIC ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
  - `pthread` might not (probably never) be a valid compilation option. It is either `-pthread`, `-pthreads` or nothing mostly. Use the info from CMakes detection.
