### PR TITLE
Make sure 3rdParty expat uses its own headers.

### DIFF
--- a/FMIL/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
+++ b/FMIL/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
@@ -62,6 +62,7 @@ else(BUILD_shared)
 endif(BUILD_shared)
 
 add_library(expat ${_SHARED} ${expat_SRCS})
+target_include_directories(expat PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 if(NOT BUILD_shared)
   target_compile_definitions(expat PUBLIC XML_STATIC)


### PR DESCRIPTION
  - The 3rdParty expat we have (inside FMIL) was probably using system headers because it did not specify include directories properly.

  - We really need to find an alternative to FMIL. It is not feasible to continue fixing all these problems that it brings with it.


