### PR TITLE
Use our 3rdParty/regex code instead of pcreposix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,12 +116,6 @@ add_library(omc::3rd::lis ALIAS lis)
 
 
 # metis
-# If MSVC use the unofficial pcre from vcpkg since there is no
-# default regex support.
-if(MSVC)
-  option(METIS_GKLIB_PCRE "enable PCRE support" ON)
-endif()
-
 omc_add_subdirectory(metis-5.1.0)
 add_library(omc::3rd::metis ALIAS metis)
 target_include_directories(metis INTERFACE metis-5.1.0/include)
@@ -141,8 +135,9 @@ add_library(omc::3rd::tbb ALIAS tbb_static)
 
 
 
-# # regex
-# omc_add_subdirectory(regex-0.12)
+# regex
+omc_add_subdirectory(regex-0.12)
+add_library(omc::3rd::regex ALIAS omcregex)
 
 # SuiteSparse
 omc_add_subdirectory(SuiteSparse-5.8.1)

--- a/metis-5.1.0/libmetis/CMakeLists.txt
+++ b/metis-5.1.0/libmetis/CMakeLists.txt
@@ -1,8 +1,4 @@
 
-if(MSVC)
-  find_package(unofficial-pcre CONFIG REQUIRED)
-endif()
-
 # Add this directory for internal users.
 include_directories(.)
 # Find sources.
@@ -13,7 +9,7 @@ add_library(metis ${METIS_LIBRARY_TYPE} ${GKlib_sources} ${metis_sources})
 if(UNIX)
   target_link_libraries(metis m)
 elseif(MSVC)
-  target_link_libraries(metis PUBLIC unofficial::pcre::pcreposix)
+  target_link_libraries(metis PUBLIC omc::3rd::regex)
 endif()
 
 if(METIS_INSTALL)


### PR DESCRIPTION
  - Using pcreposix creates (fixable) issue with the old MSVC build of OpenModelica which wants to use 3rdParty/regex. It is just an include file name issue but maybe it is better to stick to what we already have for now. We can change it later.

  - Build and make available the 3rdParty/regex code as the static library `omcregex` (for the CMake build.)
