### PR TITLE
Build omcregex only for MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,10 +134,12 @@ add_library(omc::3rd::tbb ALIAS tbb_static)
 # add_library(omc::3rd::tbb::shared ALIAS tbb)
 
 
-
 # regex
-omc_add_subdirectory(regex-0.12)
-add_library(omc::3rd::regex ALIAS omcregex)
+if(MSVC)
+  omc_add_subdirectory(regex-0.12)
+  add_library(omc::3rd::regex ALIAS omcregex)
+endif()
+
 
 # SuiteSparse
 omc_add_subdirectory(SuiteSparse-5.8.1)


### PR DESCRIPTION
  - It has some portability issues (for macOS). Probably can be fixed but it is not going to be used on those systems anyway.
