### PR TITLE
Fix FMIL merging of static libs for MSVC.

### DIFF
--- a/FMIL/Config.cmake/mergestaticlibs.cmake
+++ b/FMIL/Config.cmake/mergestaticlibs.cmake
@@ -65,7 +65,19 @@ function(merge_static_libs outlib )
 		string(TOUPPER "STATIC_LIBRARY_FLAGS_${CONFIG_TYPE}" PROPNAME)
 		set_target_properties(${outlib} PROPERTIES ${PROPNAME} "${flags}")
 	endforeach()
-	
+
+	find_program(MSVC_LIB_TOOL lib.exe)
+
+	if(NOT MSVC_LIB_TOOL)
+		message(FATAL_ERROR "LIB.EXE not found. fmil can not merge static libs.")
+	endif()
+
+	get_target_property(outfile ${outlib} LOCATION)
+	add_custom_command(TARGET ${outlib} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E remove ${outfile}
+		COMMAND ${MSVC_LIB_TOOL} /OUT:${outfile} ${libfiles}
+	)
+
   elseif(APPLE)
     # Use OSX's libtool to merge archives
 	if(multiconfig)


### PR DESCRIPTION
  - It is not really a fix but they never even implemented it.

    This should be submitted to upstream but they are very wary of improvements.

    It is exteremly difficult to have any sense of sympathy towards this library. It's bad in incrementally fascinating ways. The worst library I have ever seen without any doubt.

