### PR TITLE
cast to proper type

### DIFF
--- a/FMIL/ThirdParty/Minizip/minizip/zip.c
+++ b/FMIL/ThirdParty/Minizip/minizip/zip.c
@@ -1246,7 +1246,7 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
         unsigned char bufHead[RAND_HEAD_LEN];
         unsigned int sizeHead;
         zi->ci.encrypt = 1;
-        zi->ci.pcrc_32_tab = get_crc_table();
+        zi->ci.pcrc_32_tab = (const unsigned long*)get_crc_table();
         /*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
 
         sizeHead=crypthead(password,bufHead,RAND_HEAD_LEN,zi->ci.keys,zi->ci.pcrc_32_tab,crcForCrypting);


### PR DESCRIPTION
This is because fc40 has issues:
OMCompiler/3rdParty/FMIL/ThirdParty/Minizip/minizip/zip.c: In function ‘zipOpenNewFileInZip4_64’:
OMCompiler/3rdParty/FMIL/ThirdParty/Minizip/minizip/zip.c:1249:28: error: assignment to ‘const long unsigned int *’ from incompatible pointer type ‘const z_crc_t *’ {aka ‘const unsigned int *’} [-Wincompatible-pointer-types]
 1249 |         zi->ci.pcrc_32_tab = get_crc_table();

