### PR TITLE
Add system libffi option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(OMCompiler_3rdParty)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 # ryu
 omc_add_subdirectory(ryu)
 add_library(omc::3rd::ryu ALIAS ryu)
@@ -94,12 +96,20 @@ add_library(omc::3rd::omcgc ALIAS omcgc)
 
 
 
-#libffi
-omc_add_subdirectory(libffi)
-target_include_directories(ffi INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/libffi/include)
-# Currently the libffi setup puts the configure-generated headers in the
-# `build directory`/include folder
-target_include_directories(ffi INTERFACE ${libffi_BINARY_DIR}/include)
+# libffi
+option(OM_USE_SYSTEM_LIBFFI "Use system libffi" OFF)
+if (OM_USE_SYSTEM_LIBFFI)
+  find_package(LibFFI MODULE REQUIRED)
+  add_library(ffi INTERFACE)
+  target_include_directories(ffi INTERFACE ${LIBFFI_INCLUDE_DIRS})
+  target_link_libraries(ffi INTERFACE ${LIBFFI_LIBRARIES})
+else ()
+  omc_add_subdirectory(libffi)
+  target_include_directories(ffi INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/libffi/include)
+  # Currently the libffi setup puts the configure-generated headers in the
+  # `build directory`/include folder
+  target_include_directories(ffi INTERFACE ${libffi_BINARY_DIR}/include)
+endif ()
 add_library(omc::3rd::ffi ALIAS ffi)
 
 

--- a/cmake/FindLibFFI.cmake
+++ b/cmake/FindLibFFI.cmake
@@ -1,0 +1,27 @@
+find_package (PkgConfig QUIET)
+if (PkgConfig_FOUND)
+  pkg_check_modules (PC_LIBFFI QUIET libffi)
+endif ()
+
+# Find the headers and library
+find_path(
+  LIBFFI_INCLUDE_DIR
+  NAMES "ffi.h"
+  HINTS "${PC_LIBFFI_INCLUDE_DIRS}")
+
+find_library(
+  LIBFFI_LIBRARY
+  NAMES "ffi"
+  HINTS "${PC_LIBFFI_LIBRARY_DIRS}")
+
+set (LIBFFI_LIBRARIES ${LIBFFI_LIBRARY})
+set (LIBFFI_INCLUDE_DIRS ${LIBFFI_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibFFI DEFAULT_MSG LIBFFI_LIBRARY LIBFFI_INCLUDE_DIRS)
+
+mark_as_advanced (
+  LIBFFI_LIBRARY
+  LIBFFI_LIBRARIES
+  LIBFFI_INCLUDE_DIR
+  LIBFFI_INCLUDE_DIRS)


### PR DESCRIPTION
This allows to build openmodelica for aarch64 in conda-forge since the bundled libffi fails to compile for that arch:
```
$BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: OMCompiler/3rdParty/libffi/libffi.a(closures.c.o): in function `dlmmap.constprop.0':
 │ │ closures.c:(.text+0x15a4): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x15a8): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: OMCompiler/3rdParty/libffi/libffi.a(closures.c.o): in function `ffi_closure_alloc':
 │ │ closures.c:(.text+0x1a98): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x1a9c): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x1fbc): undefined reference to `ffi_tramp_alloc'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x1fc0): undefined reference to `ffi_tramp_alloc'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x1fd4): undefined reference to `ffi_tramp_get_addr'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x1fd8): undefined reference to `ffi_tramp_get_addr'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: OMCompiler/3rdParty/libffi/libffi.a(closures.c.o): in function `ffi_data_to_code_pointer':
 │ │ closures.c:(.text+0x31d4): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x31d8): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x3208): undefined reference to `ffi_tramp_get_addr'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x320c): undefined reference to `ffi_tramp_get_addr'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: OMCompiler/3rdParty/libffi/libffi.a(closures.c.o): in function `ffi_closure_free':
 │ │ closures.c:(.text+0x3230): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x3234): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x3254): undefined reference to `ffi_tramp_free'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x3258): undefined reference to `ffi_tramp_free'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: OMCompiler/3rdParty/libffi/libffi.a(closures.c.o): in function `ffi_tramp_is_present':
 │ │ closures.c:(.text+0x32ac): undefined reference to `ffi_tramp_is_supported'
 │ │ $BUILD_PREFIX/bin/../libexec/gcc/aarch64-conda-linux-gnu/14.3.0/ld: closures.c:(.text+0x32b0): undefined reference to `ffi_tramp_is_supported'
 │ │ collect2: error: ld returned 1 exit status

```

I dont have access to push a new branch here as stated by the contribution guide, so I'm submitting a PR anyway, maybe it can be cherry-picked by a maintainer in a branch for integration later ?

cc @adrpo @linuslangenkamp 