### PR TITLE
Fix CLAPACK porting bug

### DIFF
--- a/dgesv/lapack/ilaenv.c
+++ b/dgesv/lapack/ilaenv.c
@@ -39,7 +39,7 @@ integer ilaenv_(integer *ispec, char *name__, char *opts, integer *n1,
     integer nbmin;
     logical sname;
     extern integer ieeeck_(integer *, real *, real *);
-    char subnam[1];
+    char subnam[6];
     extern integer iparmq_(integer *, char *, char *, integer *, integer *, 
 	    integer *, integer *);
 


### PR DESCRIPTION
## Issue

dgesv produces warnings while compiling FMUs:

```
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c: In function ‘ilaenv_’:
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:200:56: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  200 |                     *(unsigned char *)&subnam[i__ - 1] = (char) (ic - 32);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:42:10: note: at offset 1 into destination object ‘subnam’ of size 1
   42 |     char subnam[1];
      |          ^~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:200:56: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  200 |                     *(unsigned char *)&subnam[i__ - 1] = (char) (ic - 32);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:42:10: note: at offset 2 into destination object ‘subnam’ of size 1
   42 |     char subnam[1];
      |          ^~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:200:56: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  200 |                     *(unsigned char *)&subnam[i__ - 1] = (char) (ic - 32);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:42:10: note: at offset 3 into destination object ‘subnam’ of size 1
   42 |     char subnam[1];
      |          ^~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:200:56: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  200 |                     *(unsigned char *)&subnam[i__ - 1] = (char) (ic - 32);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:42:10: note: at offset 4 into destination object ‘subnam’ of size 1
   42 |     char subnam[1];
      |          ^~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:200:56: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  200 |                     *(unsigned char *)&subnam[i__ - 1] = (char) (ic - 32);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/tmp/tmponyfzw4m/sources/external_solvers/ilaenv.c:42:10: note: at offset 5 into destination object ‘subnam’ of size 1
   42 |     char subnam[1];
      |          ^~~~~~
```

## Purpose

* Fixes compiler warning during FMU compilaton
* Prevents latent out-of-bounds write

## Approach

* subname has to be large enough for loop at L197-200
