### PR TITLE
Fix oneTBB build on Windows with MinGW

### DIFF
--- a/oneTBB/include/oneapi/tbb/profiling.h
+++ b/oneTBB/include/oneapi/tbb/profiling.h
@@ -132,7 +132,7 @@ namespace d1 {
         r1::call_itt_notify(static_cast<int>(t), ptr);
     }
 
-#if (_WIN32||_WIN64) && !__MINGW32__
+#if (_WIN32||_WIN64) // && !__MINGW32__  // removed for MinGW Makefiles builds, see https://github.com/uxlfoundation/oneTBB/issues/1052
     inline void itt_set_sync_name(void* obj, const wchar_t* name) {
         r1::itt_set_sync_name(obj, name);
     }


### PR DESCRIPTION
## Issue

Building oneTBB on Windows with CMake and build tools from OMDev in Powershell targeting `MinGW Makefiles` breaks:

```
[build] D:/workdir/OM/OpenModelica/OMCompiler/3rdParty/oneTBB/src/tbb/../../include/oneapi/tbb/detail/_rtm_rw_mutex.h:202:5: error: no matching function for call to 'itt_set_sync_name'
[build]   202 |     itt_set_sync_name(&obj, name);
[build]       |     ^~~~~~~~~~~~~~~~~
[build] D:/workdir/OM/OpenModelica/OMCompiler/3rdParty/oneTBB/src/tbb/../../include/oneapi/tbb/profiling.h:147:17: note: candidate function not viable: no known conversion from 'const wchar_t *' to 'const char *' for 2nd argument
[build]   147 |     inline void itt_set_sync_name( void* obj, const char* name) {
[build]       |                 ^                             ~~~~~~~~~~~~~~~~
[build] 1 warning and 5 errors generated.
```

## Changes

* Update broken if-else branch around itt_set_sync_name
* See also https://github.com/uxlfoundation/oneTBB/issues/1052
