### PR TITLE
Add the FMI Library headers that .gitignore swallowed

### DIFF
--- a/FMIL/.gitignore
+++ b/FMIL/.gitignore
@@ -1,1 +1,5 @@
-include/
+# The OpenModelica build assembles a top level include/ directory out of the
+# headers scattered around src/ (see ../CMakeLists.txt). Only that generated
+# directory is ignored -- the pattern has to stay anchored, or it also matches
+# the src/*/include/ directories that hold the real headers.
+/include/

--- a/FMIL/ThirdParty/Zlib/zlib-1.3.1/Makefile
+++ b/FMIL/ThirdParty/Zlib/zlib-1.3.1/Makefile
@@ -1,0 +1,5 @@
+all:
+	-@echo "Please use ./configure first.  Thank you."
+
+distclean:
+	make -f Makefile.in distclean

--- a/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/blast/Makefile
+++ b/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/blast/Makefile
@@ -1,0 +1,8 @@
+blast: blast.c blast.h
+	cc -DTEST -o blast blast.c
+
+test: blast
+	blast < test.pk | cmp - test.txt
+
+clean:
+	rm -f blast blast.o

--- a/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/minizip/Makefile
+++ b/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/minizip/Makefile
@@ -1,0 +1,29 @@
+CC?=cc
+CFLAGS := $(CFLAGS) -O -I../..
+
+UNZ_OBJS = miniunz.o unzip.o ioapi.o ../../libz.a
+ZIP_OBJS = minizip.o zip.o   ioapi.o ../../libz.a
+
+.c.o:
+	$(CC) -c $(CFLAGS) $*.c
+
+all: miniunz minizip
+
+miniunz:  $(UNZ_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(UNZ_OBJS)
+
+minizip:  $(ZIP_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(ZIP_OBJS)
+
+test:	miniunz minizip
+	@rm -f test.*
+	@echo hello hello hello > test.txt
+	./minizip test test.txt
+	./miniunz -l test.zip
+	@mv test.txt test.old
+	./miniunz test.zip
+	@cmp test.txt test.old
+	@rm -f test.*
+
+clean:
+	/bin/rm -f *.o *~ minizip miniunz test.*

--- a/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/puff/Makefile
+++ b/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/puff/Makefile
@@ -1,0 +1,42 @@
+CFLAGS=-O
+
+puff: puff.o pufftest.o
+
+puff.o: puff.h
+
+pufftest.o: puff.h
+
+test: puff
+	puff zeros.raw
+
+puft: puff.c puff.h pufftest.o
+	cc -fprofile-arcs -ftest-coverage -o puft puff.c pufftest.o
+
+# puff full coverage test (should say 100%)
+cov: puft
+	@rm -f *.gcov *.gcda
+	@puft -w zeros.raw 2>&1 | cat > /dev/null
+	@echo '04' | xxd -r -p | puft 2> /dev/null || test $$? -eq 2
+	@echo '00' | xxd -r -p | puft 2> /dev/null || test $$? -eq 2
+	@echo '00 00 00 00 00' | xxd -r -p | puft 2> /dev/null || test $$? -eq 254
+	@echo '00 01 00 fe ff' | xxd -r -p | puft 2> /dev/null || test $$? -eq 2
+	@echo '01 01 00 fe ff 0a' | xxd -r -p | puft -f 2>&1 | cat > /dev/null
+	@echo '02 7e ff ff' | xxd -r -p | puft 2> /dev/null || test $$? -eq 246
+	@echo '02' | xxd -r -p | puft 2> /dev/null || test $$? -eq 2
+	@echo '04 80 49 92 24 49 92 24 0f b4 ff ff c3 04' | xxd -r -p | puft 2> /dev/null || test $$? -eq 2
+	@echo '04 80 49 92 24 49 92 24 71 ff ff 93 11 00' | xxd -r -p | puft 2> /dev/null || test $$? -eq 249
+	@echo '04 c0 81 08 00 00 00 00 20 7f eb 0b 00 00' | xxd -r -p | puft 2> /dev/null || test $$? -eq 246
+	@echo '0b 00 00' | xxd -r -p | puft -f 2>&1 | cat > /dev/null
+	@echo '1a 07' | xxd -r -p | puft 2> /dev/null || test $$? -eq 246
+	@echo '0c c0 81 00 00 00 00 00 90 ff 6b 04' | xxd -r -p | puft 2> /dev/null || test $$? -eq 245
+	@puft -f zeros.raw 2>&1 | cat > /dev/null
+	@echo 'fc 00 00' | xxd -r -p | puft 2> /dev/null || test $$? -eq 253
+	@echo '04 00 fe ff' | xxd -r -p | puft 2> /dev/null || test $$? -eq 252
+	@echo '04 00 24 49' | xxd -r -p | puft 2> /dev/null || test $$? -eq 251
+	@echo '04 80 49 92 24 49 92 24 0f b4 ff ff c3 84' | xxd -r -p | puft 2> /dev/null || test $$? -eq 248
+	@echo '04 00 24 e9 ff ff' | xxd -r -p | puft 2> /dev/null || test $$? -eq 250
+	@echo '04 00 24 e9 ff 6d' | xxd -r -p | puft 2> /dev/null || test $$? -eq 247
+	@gcov -n puff.c
+
+clean:
+	rm -f puff puft *.o *.gc*

--- a/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/untgz/Makefile
+++ b/FMIL/ThirdParty/Zlib/zlib-1.3.1/contrib/untgz/Makefile
@@ -1,0 +1,14 @@
+CC=cc
+CFLAGS=-g
+
+untgz: untgz.o ../../libz.a
+	$(CC) $(CFLAGS) -o untgz untgz.o -L../.. -lz
+
+untgz.o: untgz.c ../../zlib.h
+	$(CC) $(CFLAGS) -c -I../.. untgz.c
+
+../../libz.a:
+	cd ../..; ./configure; make
+
+clean:
+	rm -f untgz untgz.o *~

--- a/FMIL/ThirdParty/Zlib/zlib-1.3.1/nintendods/Makefile
+++ b/FMIL/ThirdParty/Zlib/zlib-1.3.1/nintendods/Makefile
@@ -1,0 +1,126 @@
+#---------------------------------------------------------------------------------
+.SUFFIXES:
+#---------------------------------------------------------------------------------
+
+ifeq ($(strip $(DEVKITARM)),)
+$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
+endif
+
+include $(DEVKITARM)/ds_rules
+
+#---------------------------------------------------------------------------------
+# TARGET is the name of the output
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# DATA is a list of directories containing data files
+# INCLUDES is a list of directories containing header files
+#---------------------------------------------------------------------------------
+TARGET		:=	$(shell basename $(CURDIR))
+BUILD		:=	build
+SOURCES		:=	../../
+DATA		:=	data
+INCLUDES	:=	include
+
+#---------------------------------------------------------------------------------
+# options for code generation
+#---------------------------------------------------------------------------------
+ARCH	:=	-mthumb -mthumb-interwork
+
+CFLAGS	:=	-Wall -O2\
+		-march=armv5te -mtune=arm946e-s \
+		-fomit-frame-pointer -ffast-math \
+		$(ARCH)
+
+CFLAGS	+=	$(INCLUDE) -DARM9
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
+
+ASFLAGS	:=	$(ARCH) -march=armv5te -mtune=arm946e-s
+LDFLAGS	=	-specs=ds_arm9.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+
+#---------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level containing
+# include and lib
+#---------------------------------------------------------------------------------
+LIBDIRS	:=	$(LIBNDS)
+
+#---------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#---------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#---------------------------------------------------------------------------------
+
+export OUTPUT	:=	$(CURDIR)/lib/libz.a
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+#---------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#---------------------------------------------------------------------------------
+	export LD	:=	$(CC)
+#---------------------------------------------------------------------------------
+else
+#---------------------------------------------------------------------------------
+	export LD	:=	$(CXX)
+#---------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------
+
+export OFILES	:=	$(addsuffix .o,$(BINFILES)) \
+			$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD)
+
+.PHONY: $(BUILD) clean all
+
+#---------------------------------------------------------------------------------
+all: $(BUILD)
+	@[ -d $@ ] || mkdir -p include
+	@cp ../../*.h include
+
+lib:
+	@[ -d $@ ] || mkdir -p $@
+	
+$(BUILD): lib
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+#---------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) lib
+
+#---------------------------------------------------------------------------------
+else
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+#---------------------------------------------------------------------------------
+# main targets
+#---------------------------------------------------------------------------------
+$(OUTPUT)	:	$(OFILES)
+
+#---------------------------------------------------------------------------------
+%.bin.o	:	%.bin
+#---------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+
+-include $(DEPENDS)
+
+#---------------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------------

--- a/FMIL/src/CAPI/include/FMI3/fmi3_capi.h
+++ b/FMIL/src/CAPI/include/FMI3/fmi3_capi.h
@@ -1,0 +1,917 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+
+#ifndef FMI3_CAPI_H_
+#define FMI3_CAPI_H_
+
+#include <FMI3/fmi3_types.h>
+#include <FMI3/fmi3_function_types.h>
+#include <FMI3/fmi3_enums.h>
+#include <JM/jm_portability.h>
+#include <JM/jm_callbacks.h>
+
+typedef struct fmi3_capi_t fmi3_capi_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file fmi3_capi.h
+    \brief Public interfaces for the FMI CAPI library.
+    */
+
+/** \addtogroup fmi3_capi Standard FMI 3.0 "C" API
+ * \brief The "C" API loads and frees the FMI functions and it is through these functions all the communication with the FMU occurs. The FMI import library wraps these functions in a more convenient way.
+ *  @{
+ */
+
+/**    \addtogroup fmi3_capi_const_destroy FMI 3.0 Utility functions
+ *        \brief Utility functions used to load and free the FMI functions.
+ *    \addtogroup fmi3_capi_me FMI 3.0 (ME) Model Exchange functions
+ *        \brief List of Model Exchange wrapper functions. Common functions are not listed.
+ *    \addtogroup fmi3_capi_cs FMI 3.0 (CS) Co-Simulation functions
+ *        \brief List of Co-Simulation wrapper functions. Common functions are not listed.
+ *    \addtogroup fmi3_capi_se FMI 3.0 (CS) Scheduled-Execution functions
+ *        \brief List of Scheduled-Execution wrapper functions. Common functions are not listed.
+ *    \addtogroup fmi3_capi_common FMI 3.0 Common functions
+ *        \brief List of wrapper functions that are in common for Model Exchange, Co-Simulation and Scheduled-Execution.
+ */
+
+
+/** \addtogroup fmi3_capi_const_destroy
+ *  @{
+ */
+
+/**
+ * \brief Free a C-API struct. All memory allocated since the struct was created is freed.
+ *
+ * @param fmu A model description object returned by fmi3_import_allocate.
+ */
+void fmi3_capi_destroy_dllfmu(fmi3_capi_t* fmu);
+
+/**
+ * \brief Create a C-API struct. The C-API struct is a placeholder for the FMI DLL functions.
+ *
+ * @param callbacks ::jm_callbacks used to construct library objects.
+ * @param dllPath Full path to the FMU shared library.
+ * @param modelIdentifier The model indentifier.
+ * @param standard FMI standard that the function should load.
+ * @param instanceEnvironment The instance environment that is used during callbacks.
+ * @param logMessage The logging function the FMU will use.
+ * @return Error status. If the function returns with an error, it is not allowed to call any of the other C-API functions.
+ */
+fmi3_capi_t* fmi3_capi_create_dllfmu(jm_callbacks* callbacks, const char* dllPath, const char* modelIdentifier,
+        fmi3_instance_environment_t instanceEnvironment, fmi3_log_message_callback_ft logMessage,
+        fmi3_fmu_kind_enu_t standard);
+
+/**
+ * \brief Loads the FMI functions from the shared library. The shared library must be loaded before this function can be called, see fmi3_import_create_dllfmu.
+ *
+ * @param fmu A model description object returned by fmi3_import_allocate.
+ * @return Error status. If the function returns with an error, no other C-API functions than fmi3_import_free_dll and fmi3_import_destroy_dllfmu are allowed to be called.
+ */
+jm_status_enu_t fmi3_capi_load_fcn(fmi3_capi_t* fmu);
+
+/**
+ * \brief Loads the FMUs shared library. The shared library functions are not loaded in this call, see fmi3_import_create_dllfmu.
+ *
+ * @param fmu A model description object returned by fmi3_import_allocate.
+ * @return Error status. If the function returns with an error, no other C-API functions than fmi3_import_destroy_dllfmu are allowed to be called.
+ */
+jm_status_enu_t fmi3_capi_load_dll(fmi3_capi_t* fmu);
+
+/**
+ * \brief Frees the handle to the FMUs shared library. After this function returnes, no other C-API functions than fmi3_import_destroy_dllfmu and fmi3_import_create_dllfmu are allowed to be called.
+ *
+ * @param fmu A model description object returned by fmi3_import_allocate that has loaded the FMUs shared library, see fmi3_import_create_dllfmu.
+ * @return Error status.
+ */
+jm_status_enu_t fmi3_capi_free_dll(fmi3_capi_t* fmu);
+
+/**
+ * \brief Set CAPI debug mode flag. Setting this to a non-zero value will prevent the DLL from
+ * unloading when fmi3_capi_free_dll is invoked. This is to support valgrind debugging.
+ * Use with caution since this can cause memory leaks if debug mode is not set to 0
+ * before deallocating all the resources.
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param mode The debug mode to set.
+ */
+void fmi3_capi_set_debug_mode(fmi3_capi_t* fmu, int mode);
+
+/**
+ * \brief Get CAPI debug mode flag that was set with fmi3_capi_set_debug_mode()
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function. */
+int fmi3_capi_get_debug_mode(fmi3_capi_t* fmu);
+
+/**
+ * \brief Get the FMU kind loaded by the CAPI
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function. */
+fmi3_fmu_kind_enu_t fmi3_capi_get_fmu_kind(fmi3_capi_t* fmu);
+
+
+/**@} */
+
+/** \addtogroup fmi3_capi_common
+ *  @{
+ */
+
+/**
+ * \brief Calls the FMI function fmiGetVersion()
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI version.
+ */
+const char* fmi3_capi_get_version(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiSetDebugLogging(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param loggingOn Enable or disable the debug logger.
+ * @param nCategories Number of categories to log.
+ * @param categories Which categories to log.
+ *
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_debug_logging(fmi3_capi_t* fmu, fmi3_boolean_t loggingOn, size_t nCategories, fmi3_string_t categories[]);
+
+/**
+ * \brief Calls the FMI function fmi3InstantiateModelExchange(...)
+ *
+ * Arguments 'instanceEnvironment' and 'logMessage' are reused from #fmi3_capi_create_dllfmu.
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param instanceName The name of the instance.
+ * @param instantiationToken The instantiation token.
+ * @param resourcePath Absolute path to the FMU archive resources.
+ * @param visible Indicates whether or not the simulator application window shoule be visible.
+ * @param loggingOn Enable or disable the debug logger.
+ * @return An instance of a model, or NULL if call failed.
+ */
+fmi3_instance_t fmi3_capi_instantiate_model_exchange(fmi3_capi_t*   fmu,
+                                                     fmi3_string_t  instanceName,
+                                                     fmi3_string_t  instantiationToken,
+                                                     fmi3_string_t  resourcePath,
+                                                     fmi3_boolean_t visible,
+                                                     fmi3_boolean_t loggingOn);
+
+
+/**
+ * \brief Calls the FMI function fmi3InstantiateCoSimulation(...)
+ *
+ * Arguments 'instanceEnvironment' and 'logMessage' are reused from #fmi3_capi_create_dllfmu.
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param instanceName The name of the instance.
+ * @param instantiationToken The instantiation token.
+ * @param resourcePath Absolute path to the FMU archive resources.
+ * @param visible Indicates whether or not the simulator application window shoule be visible.
+ * @param loggingOn Enable or disable the debug logger.
+ * @param eventModeUsed Indicates whether or not 'Event Mode' is supported.
+ * @param earlyReturnAllowed Indicates whether early return is allowed.
+ * @param requiredIntermediateVariables Array of value references of all input/output variables
+ *        that the simulation algorithm intends to set/get during intermediate updates.
+ * @param nRequiredIntermediateVariables Specifies the number of entries in array
+ *        'requiredIntermediateVariables'.
+ * @param intermediateUpdate Callback for performing intermediate updates.
+ * @return An instance of a model, or NULL if call failed.
+ */
+fmi3_instance_t fmi3_capi_instantiate_co_simulation(
+        fmi3_capi_t*                         fmu,
+        fmi3_string_t                        instanceName,
+        fmi3_string_t                        instantiationToken,
+        fmi3_string_t                        resourcePath,
+        fmi3_boolean_t                       visible,
+        fmi3_boolean_t                       loggingOn,
+        fmi3_boolean_t                       eventModeUsed,
+        fmi3_boolean_t                       earlyReturnAllowed,
+        const fmi3_value_reference_t         requiredIntermediateVariables[],
+        size_t                               nRequiredIntermediateVariables,
+        fmi3_intermediate_update_callback_ft intermediateUpdate);
+
+/**
+ * \brief Calls the FMI function fmi3InstantiateScheduledExecution(...)
+ *
+ * Arguments 'instanceEnvironment' and 'logMessage' are reused from #fmi3_capi_create_dllfmu.
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param instanceName The name of the instance.
+ * @param instantiationToken The instantiation token.
+ * @param resourcePath Absolute path to the FMU archive resources.
+ * @param visible Indicates whether or not the simulator application window shoule be visible.
+ * @param loggingOn Enable or disable the debug logger.
+ * @param clockUpdate Callback for clock update.
+ * @param lockPreemption Callback for locking preemption.
+ * @param unlockPreemption Callback for unlocking preemption.
+ * @return An instance of a model, or NULL if call failed.
+ */
+fmi3_instance_t fmi3_capi_instantiate_scheduled_execution(
+        fmi3_capi_t*                         fmu,
+        fmi3_string_t                        instanceName,
+        fmi3_string_t                        instantiationToken,
+        fmi3_string_t                        resourcePath,
+        fmi3_boolean_t                       visible,
+        fmi3_boolean_t                       loggingOn,
+        fmi3_clock_update_callback_ft        clockUpdate,
+        fmi3_lock_preemption_callback_ft     lockPreemption,
+        fmi3_unlock_preemption_callback_ft   unlockPreemption);
+
+/**
+ * \brief Calls the FMI function fmiFreeInstance(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ */
+void fmi3_capi_free_instance(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiEnterInitializationMode(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param toleranceDefined True if the @p tolerance argument is to be used
+ * @param tolerance Solvers internal to the FMU should use this tolerance or finer, if @p toleranceDefined is true
+ * @param startTime Start time of the experiment
+ * @param stopTimeDefined True if the @p stopTime argument is to be used
+ * @param stopTime Stop time of the experiment, if @p stopTimeDefined is true
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_enter_initialization_mode(fmi3_capi_t* fmu,
+                                                  fmi3_boolean_t toleranceDefined,
+                                                  fmi3_float64_t tolerance,
+                                                  fmi3_float64_t startTime,
+                                                  fmi3_boolean_t stopTimeDefined,
+                                                  fmi3_float64_t stopTime);
+
+/**
+ * \brief Calls the FMI function fmiExitInitializationMode(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_exit_initialization_mode(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiEnterEventMode(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_enter_event_mode(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiTerminate(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_terminate(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiReset(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_reset(fmi3_capi_t* fmu);
+
+
+/**
+ * \brief Calls the FMI function fmiSetFloat64(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_float64(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_float64_t value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiSetFloat32(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_float32(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_float32_t value[], size_t nValues);
+
+
+/* fmi3_capi_set_intXX documentation: see Import wrapper */
+
+fmi3_status_t fmi3_capi_set_int64( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int64_t  value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_int32( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int32_t  value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_int16( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int16_t  value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_int8(  fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int8_t   value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_uint64(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint64_t value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_uint32(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint32_t value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_uint16(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint16_t value[], size_t nValues);
+fmi3_status_t fmi3_capi_set_uint8( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint8_t  value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiSetBoolean(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Number of values in 'value' vector - might not equal 'nvr' if any variable is an array.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_boolean(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        const fmi3_boolean_t value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiSetString(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Number of values in 'value' vector - might not equal 'nvr' if any variable is an array.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_string(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        const fmi3_string_t value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiSetBinary(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param sizes Array with the actual sizes of the values for binary variables.
+ * @param values Array of variable values.
+ * @param nValues Number of values in 'value' vector - might not equal 'nvr' if any variable is an array.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_binary(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        const size_t sizes[], const fmi3_binary_t values[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetFloat64(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_float64(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_float64_t value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetFloat32(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_float32(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_float32_t value[], size_t nValues);
+
+
+/* fmi3_capi_get_intXX documentation: see Import wrapper */
+
+fmi3_status_t fmi3_capi_get_int64( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int64_t  value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_int32( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int32_t  value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_int16( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int16_t  value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_int8(  fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int8_t   value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_uint64(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint64_t value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_uint32(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint32_t value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_uint16(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint16_t value[], size_t nValues);
+fmi3_status_t fmi3_capi_get_uint8( fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint8_t  value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetBoolean(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value Array of variable values.
+ * @param nValues Number of values in 'value' vector - might not equal 'nvr' if any variable is an array.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_boolean(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_boolean_t value[],
+        size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetString(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value Array of variable values.
+ * @param nValues Number of values in 'value' vector - might not equal 'nvr' if any variable is an array.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_string(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_string_t value[],
+        size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetBinary(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param sizes Array with the actual sizes of the values for binary variables.
+ * @param[out] value Array of variable values.
+ * @param nValues Number of values in 'value' vector - might not equal 'nvr' if any variable is an array.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_binary(fmi3_capi_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        size_t sizes[], fmi3_binary_t value[], size_t nValues);
+
+fmi3_status_t fmi3_capi_get_number_of_variable_dependencies(
+        fmi3_capi_t*           fmu,
+        fmi3_value_reference_t value_reference,
+        size_t*                n_dependencies);
+
+fmi3_status_t fmi3_capi_get_variable_dependencies(
+        fmi3_capi_t* fmu,
+        fmi3_value_reference_t  dependent,
+        size_t                  elementIndicesOfDependent[],
+        fmi3_value_reference_t  independents[],
+        size_t                  elementIndicesOfIndependents[],
+        fmi3_dependency_kind_t  dependencyKinds[],
+        size_t                  nDeps);
+
+fmi3_status_t fmi3_capi_get_fmu_state            (fmi3_capi_t* fmu, fmi3_FMU_state_t* s);
+fmi3_status_t fmi3_capi_set_fmu_state            (fmi3_capi_t* fmu, fmi3_FMU_state_t s);
+fmi3_status_t fmi3_capi_free_fmu_state           (fmi3_capi_t* fmu, fmi3_FMU_state_t* s);
+fmi3_status_t fmi3_capi_serialized_fmu_state_size(fmi3_capi_t* fmu, fmi3_FMU_state_t s, size_t* sz);
+fmi3_status_t fmi3_capi_serialize_fmu_state      (fmi3_capi_t* fmu, fmi3_FMU_state_t s ,fmi3_byte_t data[], size_t sz);
+fmi3_status_t fmi3_capi_de_serialize_fmu_state   (fmi3_capi_t* fmu, const fmi3_byte_t data[], size_t sz, fmi3_FMU_state_t* s);
+
+/* Getting partial derivatives */
+
+/**
+ * \brief Calls the FMI function fmiGetDirectionalDerivative(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param unknowns Value references for the derivatives/outputs to be processed
+ * @param nUnknowns Size of 'nUnknowns'.
+ * @param knowns Value references for the seed vector.
+ * @param nKnowns Size of 'knowns'.
+ * @param seed The seed vector.
+ * @param nSeed Size of 'seed'.
+ * @param sensitivity Calculated directional derivative on output.
+ * @param nSensitivity Size of 'sensitivity'.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_directional_derivative(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t unknowns[],
+        size_t nUnknowns,
+        const fmi3_value_reference_t knowns[],
+        size_t nKnowns,
+        const fmi3_float64_t seed[],
+        size_t nSeed,
+        fmi3_float64_t sensitivity[],
+        size_t nSensitivity);
+
+/**
+ * \brief Calls the FMI function fmiGetAdjointDerivative(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param unknowns Value references for the derivatives/outputs to be processed.
+ * @param nUnknowns Size of 'nUnknowns'.
+ * @param knowns Value references for the seed vector.
+ * @param nKnowns Size of 'knowns'.
+ * @param seed The seed vector.
+ * @param nSeed Size of 'seed'.
+ * @param sensitivity Calculated derivative on output.
+ * @param nSensitivity Size of 'sensitivity'.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_adjoint_derivative(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t unknowns[],
+        size_t nUnknowns,
+        const fmi3_value_reference_t knowns[],
+        size_t nKnowns,
+        const fmi3_float64_t seed[],
+        size_t nSeed,
+        fmi3_float64_t sensitivity[],
+        size_t nSensitivity);
+
+/* Entering and exiting the Configuration or Reconfiguration Mode */
+
+/**
+ * \brief Calls the FMI function fmiEnterConfigurationMode(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_enter_configuration_mode(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiExitConfigurationMode(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_exit_configuration_mode(fmi3_capi_t* fmu);
+
+/* Clock related functions */
+
+/**
+ * \brief Calls the FMI function fmiGetClock(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param values Output argument containing the values.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_clock(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_clock_t values[]);
+
+/**
+ * \brief Calls the FMI function fmiSetClock(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param values Output argument containing the values.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_clock(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_clock_t values[]);
+
+/**
+ * \brief Calls the FMI function fmiGetIntervalDecimal(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param intervals Array of size nValueReferences to retrieve the Clock intervals.
+ * @param qualifiers Array of size nValueReferences to retrieve the Clock qualifiers.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_interval_decimal(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_float64_t intervals[],
+        fmi3_interval_qualifier_t qualifiers[]);
+
+/**
+ * \brief Calls the FMI function fmiGetIntervalFraction(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences to retrieve the Clock intervals as fraction counters.
+ * @param resolutions Array of size nValueReferences to retrieve the Clock intervals as fraction resolutions.
+ * @param qualifiers Array of size nValueReferences to retrieve the Clock qualifiers.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_interval_fraction(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_uint64_t counters[],
+        fmi3_uint64_t resolutions[],
+        fmi3_interval_qualifier_t qualifiers[]);
+
+/**
+ * \brief Calls the FMI function fmiGetShiftDecimal(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param shifts Array of size nValueReferences to retrieve the Clock shifts.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_shift_decimal(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_float64_t shifts[]);
+
+/**
+ * \brief Calls the FMI function fmiGetShiftFraction(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences to retrieve the Clock shifts as fraction counters.
+ * @param resolutions Array of size nValueReferences to retrieve the Clock shifts as fraction resolutions.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_shift_fraction(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_uint64_t counters[],
+        fmi3_uint64_t resolutions[]);
+
+/**
+ * \brief Calls the FMI function fmiSetIntervalDecimal(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param intervals Array of size nValueReferences holding the Clock intervals to be set.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_interval_decimal(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_float64_t intervals[]);
+
+/**
+ * \brief Calls the FMI function fmiGetIntervalFraction(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences that holds the Clock counters to be set.
+ * @param resolutions Array of size nValueReferences that holds the Clock resolutions to be set.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_interval_fraction(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_uint64_t counters[],
+        const fmi3_uint64_t resolutions[]);
+
+/**
+ * \brief Calls the FMI function fmiSetShiftDecimal(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param shifts Array of size nValueReferences holding the Clock shifts to be set.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_shift_decimal(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_float64_t shifts[]);
+
+/**
+ * \brief Calls the FMI function fmiSetShiftFraction(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences that holds the Clock shift counters to be set.
+ * @param resolutions Array of size nValueReferences that holds the Clock shift resolutions to be set.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_shift_fraction(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_uint64_t counters[],
+        const fmi3_uint64_t resolutions[]);
+
+/**
+ * \brief Calls the FMI function fmiEvaluateDiscreteStates(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_evaluate_discrete_states(
+        fmi3_capi_t*    fmu);
+
+/**
+ * \brief Calls the FMI function fmiUpdateDiscreteStates(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param discreteStatesNeedUpdate Return arg: if the FMU needs to update the discrete states.
+ * @param terminateSimulation Return arg: if the FMU wants to terminate the simulation.
+ * @param nominalsOfContinuousStatesChanged Return arg: if the nominals of continuous states changed.
+ * @param valuesOfContinuousStatesChanged Return arg: if the values of continuous states changed.
+ * @param nextEventTimeDefined Return arg: if the value of the next time event (arg 'nextEventTime') is defined.
+ * @param nextEventTime Return arg: time for next time event.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_update_discrete_states(
+        fmi3_capi_t*    fmu,
+        fmi3_boolean_t *discreteStatesNeedUpdate,
+        fmi3_boolean_t *terminateSimulation,
+        fmi3_boolean_t *nominalsOfContinuousStatesChanged,
+        fmi3_boolean_t *valuesOfContinuousStatesChanged,
+        fmi3_boolean_t *nextEventTimeDefined,
+        fmi3_float64_t *nextEventTime);
+
+/**@} */
+
+/** \addtogroup fmi3_capi_me
+ *  @{
+ */
+
+/**
+ * \brief Calls the FMI function fmiEnterContinuousTimeMode(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_enter_continuous_time_mode(fmi3_capi_t* fmu);
+
+
+/**
+ * \brief Calls the FMI function fmiSetTime(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param time Set the current time.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_time(fmi3_capi_t* fmu, fmi3_float64_t time);
+
+/**
+ * \brief Calls the FMI function fmiSetContinuousStates(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param x Array of state values.
+ * @param nx Number of states.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_set_continuous_states(fmi3_capi_t* fmu, const fmi3_float64_t x[], size_t nx);
+
+/**
+ * \brief Calls the FMI function fmiCompletedIntegratorStep(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param noSetFMUStatePriorToCurrentPoint True if fmiSetFMUState will no
+          longer be called for time instants prior to current time in this
+          simulation run.
+ * @param[out] enterEventMode  Call fmiEnterEventMode indicator.
+ * @param[out] terminateSimulation  Terminate simulation indicator.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_completed_integrator_step(fmi3_capi_t* fmu,
+    fmi3_boolean_t noSetFMUStatePriorToCurrentPoint,
+    fmi3_boolean_t* enterEventMode, fmi3_boolean_t* terminateSimulation);
+
+/**
+ * \brief Calls the FMI function fmiGetContinuousStateDerivatives(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param[out] derivatives  Array of the continuous state derivatives.
+ * @param nx Number of continuous state derivatives.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_continuous_state_derivatives(fmi3_capi_t* fmu, fmi3_float64_t derivatives[], size_t nx);
+
+/**
+ * \brief Calls the FMI function fmiGetEventIndicators(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param[out] eventIndicators  The event indicators.
+ * @param ni Number of event indicators.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_event_indicators(fmi3_capi_t* fmu, fmi3_float64_t eventIndicators[], size_t ni);
+
+/**
+ * \brief Calls the FMI function fmiGetContinuousStates(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param[out] x  Array of state values.
+ * @param nx Number of states.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_continuous_states(fmi3_capi_t* fmu, fmi3_float64_t x[], size_t nx);
+
+/**
+ * \brief Calls the FMI function fmiGetNominalsOfContinuousStates(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param[out] nominals  The nominal values.
+ * @param nx Number of nominal values.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_nominals_of_continuous_states(fmi3_capi_t* fmu, fmi3_float64_t nominals[], size_t nx);
+
+/**
+ * \brief Calls the FMI function fmi3GetNumberOfEventIndicators(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param[out] nz  Number of event indicators.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_number_of_event_indicators(fmi3_capi_t* fmu, size_t* nz);
+
+/**
+ * \brief Calls the FMI function fmi3GetNumberOfContinuousStates(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param[out] nx  Number of continuous states.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_number_of_continuous_states(fmi3_capi_t* fmu, size_t* nx);
+
+/**@} */
+
+/** \addtogroup fmi3_capi_cs
+ *  @{
+ */
+
+/**
+ * \brief Calls the FMI function fmiEnterStepMode(...)
+ *
+ * @param fmu C-API struct that has succesfully load the FMI function.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_enter_step_mode(fmi3_capi_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiGetOutputDerivatives(...)
+ *
+ * @param fmu C-API struct that has succesfully load the FMI function.
+ * @param valueReferences Array of value references.
+ * @param nValueReferences Number of array elements.
+ * @param orders Array of derivative orders (same size as 'valueReferences').
+ * @param values Array of variable values.
+ * @param nValues Number of array elements.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_get_output_derivatives(
+        fmi3_capi_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_int32_t orders[],
+        fmi3_float64_t values[],
+        size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiDoStep(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param currentCommunicationPoint Current communication point of the master.
+ * @param communicationStepSize Communication step size.
+ * @param noSetFMUStatePriorToCurrentPoint Indicates that the master will not cal SetFMUState to a time prior to
+ *        currentCommunicationPoint.
+ * @param eventHandlingNeeded Indicates that an event was encountered by the FMU at lastSuccessfulTime.
+ * @param[out] terminate  If the FMU requests the simulation to be terminated (since the FMU reached end of
+ *        simulation time - not due to internal error).
+ * @param[out] earlyReturn  If the FMU returns early.
+ * @param[out] lastSuccessfulTime  The internal FMU time when this function returned.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_do_step(
+        fmi3_capi_t* fmu,
+        fmi3_float64_t currentCommunicationPoint,
+        fmi3_float64_t communicationStepSize,
+        fmi3_boolean_t noSetFMUStatePriorToCurrentPoint,
+        fmi3_boolean_t* eventHandlingNeeded,
+        fmi3_boolean_t* terminate,
+        fmi3_boolean_t* earlyReturn,
+        fmi3_float64_t* lastSuccessfulTime);
+
+/**
+ * \brief Calls the FMI function fmiActivateModelPartition(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param clockReference Value reference of an inputClock that will be activated.
+ * @param activationTime Simulation (virtual) time of the clock tick.
+ * @return FMI status.
+ */
+fmi3_status_t fmi3_capi_activate_model_partition(
+        fmi3_capi_t* fmu,
+        fmi3_value_reference_t clockReference,
+        fmi3_float64_t activationTime);
+
+/** @}*/
+/** @}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* End of header file FMI3_CAPI_H_ */

--- a/FMIL/src/Import/include/FMI/fmi_import_options.h
+++ b/FMIL/src/Import/include/FMI/fmi_import_options.h
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2022 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI_IMPORT_OPTIONS_H
+#define FMI_IMPORT_OPTIONS_H
+
+#include "fmilib_config.h"
+
+#include "JM/jm_portability.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief FMI Library options object.
+ */
+typedef struct fmi_util_options_t fmi_import_options_t;
+
+/**
+ * \brief Sets the flag for the platform dependent function that loads the shared library.
+ *
+ * See the platform dependent function ('dlopen' or 'LoadLibraryEx') for valid values.
+ *
+ * An example value for 'dlopen' would be RTLD_NOW|RTLD_LOCAL|RTLD_DEEPBIND, granted the
+ * system supports the 'RTLD_DEEPBIND' flag.
+ *
+ * @param options fmi_import_options_t:: opaque object pointer
+ * @param flag jm_portability_loadlibrary_flag_t:: flag value to be set
+ */
+FMILIB_EXPORT void fmi_import_set_option_loadlibrary_flag(fmi_import_options_t* options, jm_portability_loadlibrary_flag_t flag);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMI_IMPORT_OPTIONS_H */

--- a/FMIL/src/Import/include/FMI/fmi_import_terminals_and_icons.h
+++ b/FMIL/src/Import/include/FMI/fmi_import_terminals_and_icons.h
@@ -1,0 +1,115 @@
+/*
+    Copyright (C) 2024 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi_import_terminals_and_icons.h
+*  \brief Public interface to the FMI XML C-library. Handling of terminals and icons.
+*/
+
+#ifndef FMI_IMPORT_TERMINALS_AND_ICONS_H_
+#define FMI_IMPORT_TERMINALS_AND_ICONS_H_
+
+#include <stddef.h>
+
+#include <FMI2/fmi2_import.h>
+#include <FMI3/fmi3_import.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+    \defgroup fmi_termicon_import FMI Terminals and Icons import interface
+    @{
+        \defgroup fmi_import_terminals_and_icons General Handling of Terminals and Icons
+        \addtogroup  fmi_import_terminals_and_icons
+        \addtogroup  fmi2_import_terminals_and_icons
+        \addtogroup  fmi3_import_terminals_and_icons
+    @}
+*/
+
+/**
+    \addtogroup fmi_import_terminals_and_icons
+    \brief Common API for Terminals and Icons.
+    
+    Functionality and API common to FMI 2 and FMI 3 import.
+    @{ 
+*/
+
+/** \brief Opaque Terminal type */
+typedef struct fmi_xml_terminal_t fmi_import_terminal_t;
+
+/** 
+    \brief Get the variable name
+    @param term An #fmi_import_terminal_t pointer
+    @return name
+*/ 
+FMILIB_EXPORT const char* fmi_import_get_terminal_name(fmi_import_terminal_t* term);
+
+/** @} */
+
+// TODO: Should one move the FMI 2/3 specific content to separate files?
+
+/**
+    \addtogroup fmi2_import_terminals_and_icons Terminals and Icons in FMI2
+    \brief FMI2 specific API for Terminals and Icons.
+    @{ 
+*/
+
+/**
+ * \brief Returns non-zero if terminalsAndIcons.xml has been found and successfully parsed.
+ * @param fmu An #fmi2_import_t object as returned by #fmi2_import_parse_xml().
+ */
+FMILIB_EXPORT int fmi2_import_get_has_terminals_and_icons(fmi2_import_t* fmu);
+
+/**
+    \brief Get terminal by terminal name.
+    @param fmu An #fmi2_import_t object as returned by #fmi2_import_parse_xml().
+    @param name terminal name
+    @return terminal pointer. NULL if terminal with given name does not exist.
+ */
+FMILIB_EXPORT fmi_import_terminal_t* fmi2_import_get_terminal_by_name(fmi2_import_t* fmu, const char* name);
+
+/** @} */
+
+
+
+/**
+    \addtogroup fmi3_import_terminals_and_icons Terminals and Icons in FMI3
+    \brief FMI3 specific API for Terminals and Icons.
+    @{ 
+*/
+
+/**
+ * \brief Returns non-zero if terminalsAndIcons.xml has been found and successfully parsed.
+ * @param fmu An #fmi3_import_t object as returned by #fmi3_import_parse_xml().
+ */
+FMILIB_EXPORT int fmi3_import_get_has_terminals_and_icons(fmi3_import_t* fmu);
+
+/**
+    \brief Get terminal by terminal name.
+    @param fmu An #fmi3_import_t object as returned by #fmi3_import_parse_xml().
+    @param name terminal name
+    @return terminal pointer. NULL if terminal with given name does not exist.
+ */
+FMILIB_EXPORT fmi_import_terminal_t* fmi3_import_get_terminal_by_name(fmi3_import_t* fmu, const char* name);
+
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FMI_IMPORT_TERMINALS_AND_ICONS_H_

--- a/FMIL/src/Import/include/FMI3/fmi3_import.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import.h
@@ -1,0 +1,439 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_import.h
+*  \brief Public interface to the FMI import C-library.
+*/
+
+#ifndef FMI3_IMPORT_H_
+#define FMI3_IMPORT_H_
+
+#include <stddef.h>
+#include <fmilib_config.h>
+#include <JM/jm_callbacks.h>
+#include <FMI/fmi_import_util.h>
+#include <FMI/fmi_import_context.h>
+#include "FMI/fmi_import_options.h"
+
+#include <FMI3/fmi3_types.h>
+#include <FMI3/fmi3_function_types.h>
+#include <FMI3/fmi3_enums.h>
+
+#include "fmi3_import_type.h"
+#include "fmi3_import_unit.h"
+#include "fmi3_import_variable.h"
+#include "fmi3_import_variable_list.h"
+#include <FMI/fmi_import_terminals_and_icons.h>
+
+#include "fmi3_import_capi.h"
+#include "fmi3_import_convenience.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup fmi3_import FMI 3.0 import interface
+ *  All the structures used in the interfaces are intended to
+ *  be treated as opaque objects by the client code.
+ * @{
+ *      \addtogroup fmi3_import_init Constuction, destruction and error handling
+ *      \addtogroup fmi3_import_gen General information retrieval
+ *      \addtogroup fmi3_import_capi Interface to the standard FMI 3.0 "C" API
+ *      @{
+ *           \brief Convenient functions for calling the FMI functions. This interface wraps the "C" API.
+ *      @}
+ *      \addtogroup fmi3_import_options Functions for handling FMI Library options
+ * @}
+ */
+
+/**
+ * \addtogroup fmi3_import_init
+ * @{
+ */
+
+/** \brief Given directory name fmu_unzipped_path and model identifier consturct Dll/so name
+    @return Pointer to a string with the file name. Caller is responsible for freeing the memory.
+*/
+FMILIB_EXPORT char* fmi3_import_get_dll_path(const char* fmu_unzipped_path, const char* model_identifier, jm_callbacks* callBackFunctions);
+
+/**
+* \brief Retrieve the last error message.
+*
+* Error handling:
+*
+*  Many functions in the library return pointers to struct. An error is indicated by returning NULL/0-pointer.
+*  If error is returned than fmi3_import_get_last_error() functions can be used to retrieve the error message.
+*  If logging callbacks were specified then the same information is reported via logger.
+*  Memory for the error string is allocated and deallocated in the module.
+*  Client code should not store the pointer to the string since it can become invalid.
+*    @param fmu An FMU object as returned by fmi3_import_parse_xml().
+*    @return NULL-terminated string with an error message.
+*/
+FMILIB_EXPORT const char* fmi3_import_get_last_error(fmi3_import_t* fmu);
+
+/**
+\brief Clear the error message.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @return 0 if further processing is possible. If it returns 1 then the
+*    error was not recoverable. The \p fmu object should then be freed and recreated.
+*/
+FMILIB_EXPORT int fmi3_import_clear_last_error(fmi3_import_t* fmu);
+
+/**
+    \brief Release the memory allocated
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT void fmi3_import_free(fmi3_import_t* fmu);
+/** @}
+\addtogroup fmi3_import_gen
+ * \brief Functions for retrieving general model information. Memory for the strings is allocated and deallocated in the module.
+ *   All the functions take an FMU object as returned by fmi3_import_parse_xml() as a parameter.
+ *   The information is retrieved from the XML file.
+ * @{
+*/
+/**
+    \brief Get model name.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_model_name(fmi3_import_t* fmu);
+
+/** \brief Retrieve capability flags by ID. */
+FMILIB_EXPORT unsigned int fmi3_import_get_capability(fmi3_import_t* fmu, fmi3_capabilities_enu_t id);
+
+/**
+    \brief Get model identifier for ModelExchange.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_model_identifier_ME(fmi3_import_t* fmu);
+
+/**
+    \brief Get model identifier for CoSimulation.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_model_identifier_CS(fmi3_import_t* fmu);
+
+/**
+    \brief Get model identifier for ScheduledExecution.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_model_identifier_SE(fmi3_import_t* fmu);
+
+/**
+    \brief Get FMU instantiationToken.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_instantiation_token(fmi3_import_t* fmu);
+
+/**
+    \brief Get FMU description.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_description(fmi3_import_t* fmu);
+
+/**
+    \brief Get FMU author.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_author(fmi3_import_t* fmu);
+
+/**
+    \brief Get FMU copyright information.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_copyright(fmi3_import_t* fmu);
+
+/**
+    \brief Get FMU license information.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_license(fmi3_import_t* fmu);
+
+/** \brief Get FMU version.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_model_version(fmi3_import_t* fmu);
+
+/** \brief Get FMI standard version (always 3.0).
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_model_standard_version(fmi3_import_t* fmu);
+
+/** \brief Get FMU generation tool.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_generation_tool(fmi3_import_t* fmu);
+
+/** \brief Get FMU generation date and time.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT const char* fmi3_import_get_generation_date_and_time(fmi3_import_t* fmu);
+
+/** \brief Get variable naming convention used.
+    @param fmu An fmu object as returned by fmi3_import_parse_xml().
+*/
+FMILIB_EXPORT fmi3_variable_naming_convension_enu_t fmi3_import_get_naming_convention(fmi3_import_t* fmu);
+
+/** \brief Check if the start time for default experiment is specified in the XML file. */
+FMILIB_EXPORT int fmi3_import_get_default_experiment_has_start(fmi3_import_t* fmu);
+
+/** \brief Check if the stop time for default experiment is specified in the XML file. */
+FMILIB_EXPORT int fmi3_import_get_default_experiment_has_stop(fmi3_import_t* fmu);
+
+/** \brief Check if the tolerance for default experiment is specified in the XML file. */
+FMILIB_EXPORT int fmi3_import_get_default_experiment_has_tolerance(fmi3_import_t* fmu);
+
+/** \brief Check if the step size time for default experiment is specified in the XML file. */
+FMILIB_EXPORT int fmi3_import_get_default_experiment_has_step_size(fmi3_import_t* fmu);
+
+/** \brief Get the start time for default experiment as specified in the XML file.
+    If it is not specified, a default value of 0.0 is returned.
+    To determine if it is specified, use the following function: #fmi3_import_get_default_experiment_has_start
+*/
+FMILIB_EXPORT double fmi3_import_get_default_experiment_start(fmi3_import_t* fmu);
+
+/** \brief Get the stop time for default experiment as specified in the XML file.
+    If it is not specified, a default value of 1.0 is returned.
+    To determine if it is specified, use the following function: #fmi3_import_get_default_experiment_has_stop
+*/
+FMILIB_EXPORT double fmi3_import_get_default_experiment_stop(fmi3_import_t* fmu);
+
+/** \brief Get the tolerance for default experiment as specified in the XML file.
+    If it is not specified, a default value of 1e-4 is returned.
+    To determine if it is specified, use the following function: #fmi3_import_get_default_experiment_has_tolerance
+*/
+FMILIB_EXPORT double fmi3_import_get_default_experiment_tolerance(fmi3_import_t* fmu);
+
+/** \brief Get the step size for default experiment as specified in the XML file.
+    If it is not specified, a default value of 1e-2 is returned.
+    To determine if it is specified, use the following function: #fmi3_import_get_default_experiment_has_step_size
+*/
+FMILIB_EXPORT double fmi3_import_get_default_experiment_step_size(fmi3_import_t* fmu);
+
+/** \brief Get the type of the FMU. For multi-kind FMUs. Returned value might not be one of #fmi3_fmu_kind_enu_t
+    if it's a multi-kind FMU. See #fmi3_fmu_kind_enu_t for more info. */
+FMILIB_EXPORT fmi3_fmu_kind_enu_t fmi3_import_get_fmu_kind(fmi3_import_t* fmu);
+
+/**
+ * \brief Returns non-zero if the fixedInternalStepSize attribute is defined on the CoSimulation element
+ */
+FMILIB_EXPORT int fmi3_import_get_cs_has_fixed_internal_step_size(fmi3_import_t* fmu);
+
+/**
+ * \brief Returns the fixedInternalStepSize attribute if it's defined on the CoSimulation element.
+ */
+FMILIB_EXPORT double fmi3_import_get_cs_fixed_internal_step_size(fmi3_import_t* fmu);
+
+/**
+ * \brief Returns the recommendedIntermediateInputSmoothness attribute value (defined or default) on
+ * the CoSimulation element.
+ */
+FMILIB_EXPORT int fmi3_import_get_cs_recommended_intermediate_input_smoothness(fmi3_import_t* fmu);
+
+/** \brief Get the list of all the type definitions in the model*/
+FMILIB_EXPORT fmi3_import_type_definition_list_t* fmi3_import_get_type_definition_list(fmi3_import_t* fmu);
+
+/** \brief Get a list of all the unit definitions in the model. */
+FMILIB_EXPORT fmi3_import_unit_definition_list_t* fmi3_import_get_unit_definition_list(fmi3_import_t* fmu);
+
+/** \brief Get the list of all the variables in the model.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @param sortOrder Specifies the order of the variables in the list:
+        0 - original order as found in the XML file; 1 - sorted alfabetically by variable name; 2 sorted by types/value references.
+* @return a variable list with all the variables in the model.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_variable_list(fmi3_import_t* fmu, int sortOrder);
+
+/** \brief Create a variable list with a single variable.
+
+    @param fmu An FMU object that this variable list will reference.
+    @param v A variable.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_create_var_list(fmi3_import_t* fmu, fmi3_import_variable_t* v);
+
+/** \brief Get the number of vendors that had annotations in the XML*/
+FMILIB_EXPORT size_t fmi3_import_get_vendors_num(fmi3_import_t* fmu);
+
+/** \brief Get the name of the vendor with that had annotations in the XML by index */
+FMILIB_EXPORT const char* fmi3_import_get_vendor_name(fmi3_import_t* fmu, size_t index);
+
+/** \brief Get the number of log categories defined in the XML */
+FMILIB_EXPORT size_t fmi3_import_get_log_categories_num(fmi3_import_t* fmu);
+
+/** \brief Get the log category by index */
+FMILIB_EXPORT const char* fmi3_import_get_log_category(fmi3_import_t* fmu, size_t index);
+
+/** \brief Get the log category description by index */
+FMILIB_EXPORT const char* fmi3_import_get_log_category_description(fmi3_import_t* fmu, size_t index);
+
+/** \brief Get the number of source files for ME defined in the XML */
+FMILIB_EXPORT size_t fmi3_import_get_source_files_me_num(fmi3_import_t* fmu);
+
+/** \brief Get the ME source file by index */
+FMILIB_EXPORT const char* fmi3_import_get_source_file_me(fmi3_import_t* fmu, size_t index);
+
+/** \brief Get the number of source files for CS defined in the XML */
+FMILIB_EXPORT size_t fmi3_import_get_source_files_cs_num(fmi3_import_t* fmu);
+
+/** \brief Get the CS source file by index */
+FMILIB_EXPORT const char* fmi3_import_get_source_file_cs(fmi3_import_t* fmu, size_t index);
+
+/**
+    \brief Get variable by variable name. Alias variable names result in their base variable.
+    @param fmu - An fmu object as returned by fmi3_import_parse_xml().
+    @param name - variable name
+    @return variable pointer.
+*/
+FMILIB_EXPORT fmi3_import_variable_t* fmi3_import_get_variable_by_name(fmi3_import_t* fmu, const char* name);
+
+/**
+    \brief Get variable by value reference.
+    @param fmu - An fmu object as returned by fmi3_import_parse_xml().
+    @param vr - value reference
+    @return variable pointer.
+*/
+FMILIB_EXPORT fmi3_import_variable_t* fmi3_import_get_variable_by_vr(fmi3_import_t* fmu, fmi3_value_reference_t vr);
+
+/** \brief Get the list of all the output variables in the model.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @return a variable list with all the output variables in the model.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_outputs_list(fmi3_import_t* fmu);
+
+/** \brief Get the list of all the continuous state derivative variables in the model.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @return a variable list with all the continuous state derivatives in the model.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_continuous_state_derivatives_list(fmi3_import_t* fmu);
+
+/** \brief Get the list of all the clocked state variables in the model.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @return a variable list with all the clocked states in the model.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_clocked_states_list(fmi3_import_t* fmu);
+
+/** \brief Get the list of all the initial unknown variables in the model.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @return a variable list with all the initial unknowns in the model.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_initial_unknowns_list(fmi3_import_t* fmu);
+
+/** \brief Get the list of all the event indicator variables in the model.
+* @param fmu An FMU object as returned by fmi3_import_parse_xml().
+* @return a variable list with all the event indicators in the model.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_event_indicators_list(fmi3_import_t* fmu);
+
+/** \brief Get dependency information for an Output.
+ * @param fmu              - An FMU object as returned by fmi3_import_parse_xml().
+ * @param variable         - A model variable in fmi3_import_get_outputs_list(...)
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not an Output), invalid inputs or unexpected failures
+ */
+FMILIB_EXPORT int fmi3_import_get_output_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for a ContinuousStateDerivative.
+ * @param fmu              - An FMU object as returned by fmi3_import_parse_xml().
+ * @param variable         - A model variable in fmi3_import_get_continuous_state_derivatives_list(...)
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not a ContinuousStateDerivative), invalid inputs or unexpected failures
+ */
+FMILIB_EXPORT int fmi3_import_get_continuous_state_derivative_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for a ClockedState.
+ * @param fmu              - An FMU object as returned by fmi3_import_parse_xml().
+ * @param variable         - A model variable in fmi3_import_get_clocked_states_list(...)
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not a ClockedState), invalid inputs or unexpected failures
+ */
+FMILIB_EXPORT int fmi3_import_get_clocked_state_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for an InitialUnknown.
+ * @param fmu              - An FMU object as returned by fmi3_import_parse_xml().
+ * @param variable         - A model variable in fmi3_import_get_initial_unknowns_list(...)
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not an InitialUnknown), invalid inputs or unexpected failures
+ */
+FMILIB_EXPORT int fmi3_import_get_initial_unknown_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for an EventIndicator.
+ * @param fmu              - An FMU object as returned by fmi3_import_parse_xml().
+ * @param variable         - A model variable in fmi3_import_get_event_indicators_list(...)
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not an EventIndicator), invalid inputs or unexpected failures
+ */
+FMILIB_EXPORT int fmi3_import_get_event_indicator_dependencies(fmi3_import_t* fmu, fmi3_import_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/**@} */
+
+/**
+ * \addtogroup fmi3_import_options
+ * @{
+ */
+
+/**
+ * Returns the fmi_import_options_t:: object.
+ *
+ * \param fmu - an fmu object as returned by fmi3_import_parse_xml().
+ * \return fmi_import_options_t:: opaque object pointer
+ */
+FMILIB_EXPORT fmi_import_options_t* fmi3_import_get_options(fmi3_import_t* fmu);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/FMIL/src/Import/include/FMI3/fmi3_import_capi.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import_capi.h
@@ -1,0 +1,1125 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI3_IMPORT_CAPI_H_
+#define FMI3_IMPORT_CAPI_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <JM/jm_callbacks.h>
+#include <FMI/fmi_import_util.h>
+#include <FMI/fmi_import_context.h>
+
+
+#include <FMI3/fmi3_types.h>
+#include <FMI3/fmi3_function_types.h>
+#include <FMI3/fmi3_enums.h>
+
+/**
+\file fmi3_import_capi.h
+Wrapper functions for the FMI 3.0 functions
+*/
+
+/**
+ * \addtogroup fmi3_import_capi
+ * @{
+ */
+
+/**    \addtogroup fmi3_import_capi_const_destroy FMI 3.0 Constructor and Destructor
+ * \brief Functions for instantiating and freeing the container of the struct that is responsible for the FMI functions.
+ *
+ *    Before any of the FMI functions may be called, the construction function must instantiate a fmi_import_t module.
+ *    After the fmi_import_t module has been succesfully instantiated, all the FMI functions can be called. To unload
+ *    the FMI functions, the destroy functions shall be called.
+ *
+ *    \addtogroup fmi3_import_capi_me FMI 3.0 (ME) Model Exchange functions
+ * \brief List of Model Exchange wrapper functions. Common functions are not listed.
+ *    \addtogroup fmi3_import_capi_cs FMI 3.0 (CS) Co-Simulation functions
+ * \brief List of Co-Simulation wrapper functions. Common functions are not listed.
+ *    \addtogroup fmi3_import_capi_common FMI 3.0 (ME & CS) Common functions
+ * \brief List of wrapper functions that are in common for both Model Exchange and Co-Simulation.
+ */
+
+/**
+ * \addtogroup fmi3_import_capi_const_destroy
+ * @{
+ */
+
+/**
+ * \brief Create a C-API struct. The C-API struct is a placeholder for the FMI DLL functions.
+ *
+ * This function may only be called once if it returned succesfully. fmi3_import_destroy_dllfmu
+ * must be called before this function can be called again.
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml().
+ * @param fmuKind Specifies if ModelExchange or CoSimulation binary should be loaded.
+ * @param instanceEnvironment The instance environment that is used during callbacks. If NULL, and 'logMessage' is also
+          NULL, then fmi3_log_forwarding is utitlized to provide logging.
+ * @param logMessage The logging function the FMU will use. If NULL, and 'instanceEnvironment' is also
+          NULL, then fmi3_log_forwarding is utitlized to provide logging.
+ * @return Error status. If the function returns with an error, it is not allowed to call any of the other C-API functions.
+ */
+FMILIB_EXPORT jm_status_enu_t fmi3_import_create_dllfmu(fmi3_import_t* fmu, fmi3_fmu_kind_enu_t fmuKind, const fmi3_instance_environment_t instanceEnvironment, const fmi3_log_message_callback_ft logMessage);
+
+/** \brief Free a C-API struct. All memory allocated since the struct was created is freed.
+ *
+ * @param fmu A model description object returned from fmi3_import_parse_xml().
+ */
+FMILIB_EXPORT void fmi3_import_destroy_dllfmu(fmi3_import_t* fmu);
+
+/**
+ * \brief Set CAPI debug mode flag. Setting to non-zero prevents DLL unloading in fmi3_import_destroy_dllfmu
+ *  while all the memory is deallocated. This is to support valgrind debugging.
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param mode The debug mode to set.
+ */
+FMILIB_EXPORT void fmi3_import_set_debug_mode(fmi3_import_t* fmu, int mode);
+/**@} */
+
+/**
+ * \addtogroup fmi3_import_capi_common
+ * @{
+ */
+
+/**
+ * \brief Wrapper for the FMI function fmiGetVersion()
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI version.
+ */
+FMILIB_EXPORT const char* fmi3_import_get_version(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetDebugLogging(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param loggingOn Enable or disable the debug logger.
+ * @param nCategories Number of categories to log.
+ * @param categories Which categories to log.
+* @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_debug_logging(fmi3_import_t* fmu, fmi3_boolean_t loggingOn, size_t nCategories, fmi3_string_t categories[]);
+
+/**
+ * \brief Wrapper for the FMI function fmi3InstantiateModelExchange(...)
+ *
+ * Arguments 'instanceEnvironment' and 'logMessage' are reused from #fmi3_import_create_dllfmu.
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see
+ *   fmi3_import_create_dllfmu().
+ * @param instanceName The name of the instance.
+ * @param resourcePath Absolute path URI to the FMU archive resources. If this is NULL pointer the FMU will get the
+ *   path to the unzipped location.
+ * @param visible Indicates whether or not the simulator application window shoule be visible.
+ * @param loggingOn Enable or disable the debug logger.
+ * @return Error status. Returnes jm_status_error if FMI function returned NULL, otherwise jm_status_success.
+ */
+FMILIB_EXPORT jm_status_enu_t fmi3_import_instantiate_model_exchange(
+        fmi3_import_t* fmu,
+        fmi3_string_t  instanceName,
+        fmi3_string_t  resourcePath,
+        fmi3_boolean_t visible,
+        fmi3_boolean_t loggingOn);
+
+/**
+ * \brief Wrapper for the FMI function fmi3InstantiateCoSimulation(...)
+ *
+ * Arguments 'instanceEnvironment' and 'logMessage' are reused from #fmi3_import_create_dllfmu.
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see
+ *   fmi3_import_create_dllfmu().
+ * @param instanceName The name of the instance.
+ * @param resourcePath Absolute path URI to the FMU archive resources. If this is NULL pointer the FMU will get the
+ *   path to the unzipped location.
+ * @param visible Indicates whether or not the simulator application window shoule be visible.
+ * @param loggingOn Enable or disable the debug logger.
+ * @param eventModeUsed Indicates whether or not 'Event Mode' is supported.
+ * @param earlyReturnAllowed Indicates whether early return is allowed.
+ * @param requiredIntermediateVariables Array of value references of all input/output variables
+ *        that the simulation algorithm intends to set/get during intermediate updates.
+ * @param nRequiredIntermediateVariables Specifies the number of entries in array
+ *        'requiredIntermediateVariables'.
+ * @param intermediateUpdate Callback for performing intermediate updates.
+ * @return Error status. Returnes jm_status_error if FMI function returned NULL, otherwise jm_status_success.
+ */
+FMILIB_EXPORT jm_status_enu_t fmi3_import_instantiate_co_simulation(
+        fmi3_import_t*                       fmu,
+        fmi3_string_t                        instanceName,
+        fmi3_string_t                        resourcePath,
+        fmi3_boolean_t                       visible,
+        fmi3_boolean_t                       loggingOn,
+        fmi3_boolean_t                       eventModeUsed,
+        fmi3_boolean_t                       earlyReturnAllowed,
+        const fmi3_value_reference_t         requiredIntermediateVariables[],
+        size_t                               nRequiredIntermediateVariables,
+        fmi3_intermediate_update_callback_ft intermediateUpdate);
+
+/**
+ * \brief Wrapper for the FMI function fmi3InstantiateScheduledExecution(...)
+ *
+ * Arguments 'instanceEnvironment' and 'logMessage' are reused from #fmi3_import_create_dllfmu.
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see
+ *   fmi3_import_create_dllfmu().
+ * @param instanceName The name of the instance.
+ * @param resourcePath Absolute path URI to the FMU archive resources. If this is NULL pointer the FMU will get the
+ *   path to the unzipped location.
+ * @param visible Indicates whether or not the simulator application window shoule be visible.
+ * @param loggingOn Enable or disable the debug logger.
+ * @param clockUpdate Callback for clock update.
+ * @param lockPreemption Callback for locking preemption.
+ * @param unlockPreemption Callback for unlocking preemption.
+ * @return Error status. Returnes jm_status_error if FMI function returned NULL, otherwise jm_status_success.
+ */
+FMILIB_EXPORT jm_status_enu_t fmi3_import_instantiate_scheduled_execution(
+        fmi3_import_t*                       fmu,
+        fmi3_string_t                        instanceName,
+        fmi3_string_t                        resourcePath,
+        fmi3_boolean_t                       visible,
+        fmi3_boolean_t                       loggingOn,
+        fmi3_clock_update_callback_ft        clockUpdate,
+        fmi3_lock_preemption_callback_ft     lockPreemption,
+        fmi3_unlock_preemption_callback_ft   unlockPreemption);
+
+/**
+ * \brief Wrapper for the FMI function fmiFreeInstance(...)
+ *
+ * @param fmu An fmu description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ */
+FMILIB_EXPORT void fmi3_import_free_instance(fmi3_import_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiEnterInitializationMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param toleranceDefined True if the @p tolerance argument is to be used
+ * @param tolerance Solvers internal to the FMU should use this tolerance or finer, if @p toleranceDefined is true
+ * @param startTime Start time of the experiment
+ * @param stopTimeDefined True if the @p stopTime argument is to be used
+ * @param stopTime Stop time of the experiment, if @p stopTimeDefined is true
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_enter_initialization_mode(
+        fmi3_import_t* fmu,
+        fmi3_boolean_t toleranceDefined,
+        fmi3_float64_t tolerance,
+        fmi3_float64_t startTime,
+        fmi3_boolean_t stopTimeDefined,
+        fmi3_float64_t stopTime);
+
+/**
+ * \brief Calls the FMI function fmiExitInitializationMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_exit_initialization_mode(fmi3_import_t* fmu);
+
+/**
+ * \brief Calls the FMI function fmiEnterEventMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_enter_event_mode(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiTerminate(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_terminate(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiReset(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_reset(fmi3_import_t* fmu);
+
+
+/**
+ * \brief Wrapper for the FMI function fmiSetFloat64(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_float64(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_float64_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetFloat32(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_float32(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_float32_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetInt64(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_int64(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int64_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetInt32(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_int32(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int32_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetInt16(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_int16(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int16_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetInt8(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_int8(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_int8_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetUInt64(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_uint64(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint64_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetUInt32(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_uint32(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint32_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetUInt16(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_uint16(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint16_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetUInt8(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_uint8(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, const fmi3_uint8_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetBoolean(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_boolean(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        const fmi3_boolean_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetString(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_string(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        const fmi3_string_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetBinary(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param sizes Array with the actual sizes of the values for binary variables.
+ * @param value Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_binary(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        const size_t sizes[], const fmi3_binary_t value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetFloat64(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_float64(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_float64_t value[], size_t nValues);
+
+/**
+ * \brief Calls the FMI function fmiGetFloat32(...)
+ *
+ * @param fmu C-API struct that has succesfully loaded the FMI function.
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_float32(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_float32_t value[], size_t nValues);
+
+
+/**
+ * \brief Wrapper for the FMI function fmiGetInt64(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_int64(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int64_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetInt32(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_int32(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int32_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetInt16(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_int16(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int16_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetInt8(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_int8(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_int8_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetUInt64(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_uint64(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint64_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetUInt32(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_uint32(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint32_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetUInt16(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_uint16(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint16_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetUInt8(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_uint8(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr, fmi3_uint8_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetBoolean(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_boolean(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        fmi3_boolean_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetString(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_string(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        fmi3_string_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetBinary(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr Array of value references.
+ * @param nvr Number of array elements.
+ * @param[out] sizes  Array with the actual sizes of the values for binary variables.
+ * @param[out] value  Array of variable values.
+ * @param nValues Total number of variable values, i.e. the number of elements in each array + the number of scalar variables.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_binary(fmi3_import_t* fmu, const fmi3_value_reference_t vr[], size_t nvr,
+        size_t sizes[], fmi3_binary_t value[], size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmi3GetNumberOfVariableDependencies(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param vr The value reference of a variable.
+ * @param nDeps Return argument that will hold the number of dependencies.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_number_of_variable_dependencies(
+        fmi3_import_t*         fmu,
+        fmi3_value_reference_t vr,
+        size_t*                nDeps);
+
+/**
+ * \brief Wrapper for the FMI function fmi3GetVariableDependencies(...)
+ *  For arrays the meaning is (for scalars: ignore the element_indicies_...):
+ *    dependent[element_indicies_of_dependent[i]] depends on independents[i][element_indices_of_independents[i]], kind: dependency_kinds[i]
+ *  element_indicies_... are index 1 based and sorted by order of dimension for higher dimension arrays (2D: row first).
+ *  element_indicies_... == 0 means dependency on all indices.
+ *  Output arrays must be allocated by the user.
+ *
+ * @param[in] fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[in] dependent The value reference of a variable for which we want to get dependencies.
+ * @param[in,out] elementIndicesOfDependent Return argument that will hold an array of indices in the array 'dependent'.
+ * @param[in,out] independents Return argument that will hold an array of value references to variables there is a dependency to.
+ * @param[in,out] elementIndicesOfIndependent Return argument that will hold an array of indices in 'independents' array.
+ * @param[in,out] dependencyKinds Return argument that will hold an array of the dependency kinds.
+ * @param[in] nDeps Specifies the allocated size for the return arguments. Should equal the size retrieved with #fmi3_import_get_number_of_variable_dependencies.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_variable_dependencies(
+        fmi3_import_t*          fmu,
+        fmi3_value_reference_t  dependent,
+        size_t                  elementIndicesOfDependent[],
+        fmi3_value_reference_t  independents[],
+        size_t                  elementIndicesOfIndependent[],
+        fmi3_dependency_kind_t  dependencyKinds[],
+        size_t                  nDeps);
+
+
+/**
+ * \brief Wrapper for the FMI function fmiGetFMUState(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param s The state object to be set by the FMU
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_fmu_state(fmi3_import_t* fmu, fmi3_FMU_state_t* s);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetFMUState(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param s The FMU state object
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_fmu_state(fmi3_import_t* fmu, fmi3_FMU_state_t s);
+
+/**
+ * \brief Wrapper for the FMI function fmiFreeFMUState(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param s The FMU state object
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_free_fmu_state(fmi3_import_t* fmu, fmi3_FMU_state_t* s);
+
+/**
+ * \brief Wrapper for the FMI function fmiSerializedFMUStateSize(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param s The FMU state object
+ * @param sz The size of the serialized state in bytes
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_serialized_fmu_state_size(fmi3_import_t* fmu, fmi3_FMU_state_t s, size_t* sz);
+
+/**
+ * \brief Wrapper for the FMI function fmiSerializeFMUState(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param s The FMU state object
+ * @param data The buffer that will receive serialized FMU state
+ * @param sz The size of the data buffer
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_serialize_fmu_state(fmi3_import_t* fmu, fmi3_FMU_state_t s, fmi3_byte_t data[], size_t sz);
+
+/**
+ * \brief Wrapper for the FMI function fmiSerializeFMUState(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param data The buffer that contains serialized FMU state
+ * @param sz The size of the data buffer
+ * @param s The FMU state object to be created
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_de_serialize_fmu_state(fmi3_import_t* fmu, const fmi3_byte_t data[], size_t sz, fmi3_FMU_state_t* s);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetDirectionalDerivative(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param unknowns Value references for the derivatives/outputs to be processed
+ * @param nUnknowns Size of 'nUnknowns'.
+ * @param knowns Value references for the seed vector.
+ * @param nKnowns Size of 'knowns'.
+ * @param seed The seed vector.
+ * @param nSeed Size of 'seed'.
+ * @param sensitivity Calculated directional derivative on output.
+ * @param nSensitivity Size of 'sensitivity'.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_directional_derivative(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t unknowns[],
+        size_t nUnknowns,
+        const fmi3_value_reference_t knowns[],
+        size_t nKnowns,
+        const fmi3_float64_t seed[],
+        size_t nSeed,
+        fmi3_float64_t sensitivity[],
+        size_t nSensitivity);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetAdjointDerivative(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param unknowns Value references for the derivatives/outputs to be processed
+ * @param nUnknowns Size of 'nUnknowns'.
+ * @param knowns Value references for the seed vector.
+ * @param nKnowns Size of 'knowns'.
+ * @param seed The seed vector.
+ * @param nSeed Size of 'seed'.
+ * @param sensitivity Calculated directional derivative on output.
+ * @param nSensitivity Size of 'sensitivity'.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_adjoint_derivative(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t unknowns[],
+        size_t nUnknowns,
+        const fmi3_value_reference_t knowns[],
+        size_t nKnowns,
+        const fmi3_float64_t seed[],
+        size_t nSeed,
+        fmi3_float64_t sensitivity[],
+        size_t nSensitivity);
+
+/**
+ * \brief Wrapper for the FMI function fmiEnterConfigurationMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_enter_configuration_mode(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiExitConfigurationMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_exit_configuration_mode(fmi3_import_t* fmu);
+
+/* Clock related functions */
+
+/**
+ * \brief Wrapper for the FMI function fmiGetClock(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param values Output argument containing the values.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_clock(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_clock_t values[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetClock(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param values Output argument containing the values.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_clock(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_clock_t values[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetIntervalDecimal(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param intervals Array of size nValueReferences to retrieve the Clock intervals.
+ * @param qualifiers Array of size nValueReferences to retrieve the Clock qualifiers.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_interval_decimal(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_float64_t intervals[],
+        fmi3_interval_qualifier_t qualifiers[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetIntervalFraction(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences to retrieve the Clock intervals as fraction counters.
+ * @param resolutions Array of size nValueReferences to retrieve the Clock intervals as fraction resolutions.
+ * @param qualifiers Array of size nValueReferences to retrieve the Clock qualifiers.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_interval_fraction(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_uint64_t counters[],
+        fmi3_uint64_t resolutions[],
+        fmi3_interval_qualifier_t qualifiers[]);
+
+/**
+ * \brief Wrapper for the FMI function fmi3GetShiftDecimal(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param shifts Array of size nValueReferences to retrieve the Clock shifts.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_shift_decimal(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_float64_t shifts[]);
+
+/**
+ * \brief Wrapper for the FMI function fmi3GetShiftFraction(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences to retrieve the Clock shifts as fraction counters.
+ * @param resolutions Array of size nValueReferences to retrieve the Clock shifts as fraction resolutions.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_shift_fraction(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_uint64_t counters[],
+        fmi3_uint64_t resolutions[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetIntervalDecimal(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param intervals Array of size nValueReferences holding the Clock intervals to be set.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_interval_decimal(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_float64_t intervals[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetIntervalFraction(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences that holds the Clock counters to be set.
+ * @param resolutions Array of size nValueReferences that holds the Clock resolutions to be set.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_interval_fraction(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_uint64_t counters[],
+        const fmi3_uint64_t resolutions[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetShiftDecimal(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param shifts Array of size nValueReferences holding the Clock shifts to be set.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_shift_decimal(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_float64_t shifts[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetShiftFraction(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references to clock variables.
+ * @param nValueReferences Number of elements in 'valueReferences' array.
+ * @param counters Array of size nValueReferences that holds the Clock shift counters to be set.
+ * @param resolutions Array of size nValueReferences that holds the Clock shift resolutions to be set.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_shift_fraction(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_uint64_t counters[],
+        const fmi3_uint64_t resolutions[]);
+
+/**
+ * \brief Wrapper for the FMI function fmiEvaluateDiscreteStates(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+*/
+FMILIB_EXPORT fmi3_status_t fmi3_import_evaluate_discrete_states(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiUpdateDiscreteStates(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param discreteStatesNeedUpdate Return arg: if the FMU needs to update the discrete states.
+ * @param terminateSimulation Return arg: if the FMU wants to terminate the simulation.
+ * @param nominalsOfContinuousStatesChanged Return arg: if the nominals of continuous states changed.
+ * @param valuesOfContinuousStatesChanged Return arg: if the values of continuous states changed.
+ * @param nextEventTimeDefined Return arg: if the value of the next time event (arg 'nextEventTime') is defined.
+ * @param nextEventTime Return arg: time for next time event.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_update_discrete_states(
+        fmi3_import_t*  fmu,
+        fmi3_boolean_t *discreteStatesNeedUpdate,
+        fmi3_boolean_t *terminateSimulation,
+        fmi3_boolean_t *nominalsOfContinuousStatesChanged,
+        fmi3_boolean_t *valuesOfContinuousStatesChanged,
+        fmi3_boolean_t *nextEventTimeDefined,
+        fmi3_float64_t *nextEventTime);
+
+/**@} */
+
+/**
+ * \addtogroup fmi3_import_capi_me
+ * @{
+ */
+
+/**
+ * \brief Calls the FMI function fmiEnterContinuousTimeMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_enter_continuous_time_mode(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetTime(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param time Set the current time.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_time(fmi3_import_t* fmu, fmi3_float64_t time);
+
+/**
+ * \brief Wrapper for the FMI function fmiSetContinuousStates(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param x Array of state values.
+ * @param nx Number of states.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_set_continuous_states(fmi3_import_t* fmu, const fmi3_float64_t x[], size_t nx);
+
+/**
+ * \brief Wrapper for the FMI function fmiCompletedIntegratorStep(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param noSetFMUStatePriorToCurrentPoint True if fmiSetFMUState will no
+          longer be called for time instants prior to current time in this
+          simulation run.
+ * @param[out] enterEventMode  Call fmiEnterEventMode indicator.
+ * @param[out] terminateSimulation  Terminate simulation indicator.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_completed_integrator_step(fmi3_import_t* fmu,
+    fmi3_boolean_t noSetFMUStatePriorToCurrentPoint,
+    fmi3_boolean_t* enterEventMode, fmi3_boolean_t* terminateSimulation);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetDerivatives(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[out] derivatives  Array of the derivatives.
+ * @param nx Number of derivatives.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_derivatives(fmi3_import_t* fmu, fmi3_float64_t derivatives[], size_t nx);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetEventIndicators(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[out] eventIndicators  The event indicators.
+ * @param ni Number of event indicators.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_event_indicators(fmi3_import_t* fmu, fmi3_float64_t eventIndicators[], size_t ni);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetContinuousStates(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[out] x  Array of state values.
+ * @param nx Number of states.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_continuous_states(fmi3_import_t* fmu, fmi3_float64_t x[], size_t nx);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetNominalsOfContinuousStates(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[out] nominals  The nominal values.
+ * @param nx Number of nominal values.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_nominals_of_continuous_states(fmi3_import_t* fmu, fmi3_float64_t nominals[], size_t nx);
+
+
+/**
+ * \brief Wrapper for the FMI function fmi3GetNumberOfEventIndicators(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[out] nz  Number of event indicators.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_number_of_event_indicators(fmi3_import_t* fmu, size_t* nz);
+
+/**
+ * \brief Wrapper for the FMI function fmi3GetNumberOfContinuousStates(...)
+ * if the FMU has been instantiated. Before instantiation the XML is instead
+ * examined. The returned value is expected to be the same.
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param[out] nx  Number of continuous states.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_number_of_continuous_states(fmi3_import_t* fmu, size_t* nx);
+
+/**@} */
+
+/**
+ * \addtogroup fmi3_import_capi_cs
+ * @{
+ */
+
+/**
+ * \brief Wrapper for the FMI function fmiEnterStepMode(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_enter_step_mode(fmi3_import_t* fmu);
+
+/**
+ * \brief Wrapper for the FMI function fmiGetOutputDerivatives(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param valueReferences Array of value references.
+ * @param nValueReferences Number of array elements.
+ * @param orders Array of derivative orders (same size as 'valueReferences').
+ * @param values Array of variable values.
+ * @param nValues Number of array elements.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_get_output_derivatives(
+        fmi3_import_t* fmu,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_int32_t orders[],
+        fmi3_float64_t values[],
+        size_t nValues);
+
+/**
+ * \brief Wrapper for the FMI function fmiDoStep(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param currentCommunicationPoint Current communication point of the master.
+ * @param communicationStepSize Communication step size.
+ * @param noSetFMUStatePriorToCurrentPoint Indicates that the master will not cal SetFMUState to a time prior to
+ *        currentCommunicationPoint.
+ * @param eventHandlingNeeded Indicates that an event was encountered by the FMU at lastSuccessfulTime.
+ * @param[out] terminate  If the FMU requests the simulation to be terminated (since the FMU reached end of
+ *        simulation time - not due to internal error).
+ * @param[out] earlyReturn  If the FMU returns early.
+ * @param[out] lastSuccessfulTime  The internal FMU time when this function returned.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_do_step(
+        fmi3_import_t* fmu,
+        fmi3_float64_t currentCommunicationPoint,
+        fmi3_float64_t communicationStepSize,
+        fmi3_boolean_t noSetFMUStatePriorToCurrentPoint,
+        fmi3_boolean_t* eventHandlingNeeded,
+        fmi3_boolean_t* terminate,
+        fmi3_boolean_t* earlyReturn,
+        fmi3_float64_t* lastSuccessfulTime);
+
+/**
+ * \brief Wrapper for the FMI function fmiActivateModelPartition(...)
+ *
+ * @param fmu A model description object returned by fmi3_import_parse_xml() that has loaded the FMI functions, see fmi3_import_create_dllfmu().
+ * @param clockReference Value reference of an inputClock that will be activated.
+ * @param activationTime Simulation (virtual) time of the clock tick.
+ * @return FMI status.
+ */
+FMILIB_EXPORT fmi3_status_t fmi3_import_activate_model_partition(
+        fmi3_import_t* fmu,
+        fmi3_value_reference_t clockReference,
+        fmi3_float64_t activationTime);
+
+/**@} */
+
+/**@} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* End of header FMI3_IMPORT_CAPI_H_ */

--- a/FMIL/src/Import/include/FMI3/fmi3_import_convenience.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import_convenience.h
@@ -1,0 +1,213 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_import_convenience.h
+*  \brief Public interface to the FMI import C-library. Convenience functions.
+*
+*  The functions in this file are provided for convenience. The functionality
+*  is already available via other lower level functions.
+*/
+
+#ifndef FMI3_IMPORT_CONVENIENCE_H_
+#define FMI3_IMPORT_CONVENIENCE_H_
+
+#include <FMI/fmi_import_context.h>
+#include <FMI3/fmi3_function_types.h>
+#include "fmi3_import_variable.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+        /**
+    \addtogroup fmi3_import
+    @{
+    \addtogroup fmi3_import_convenience Convenience functions
+    @}
+    \addtogroup fmi3_import_convenience Convenience functions
+    \brief The functions in this module are provided for convenience. The functionality
+    *  is already available via other lower level functions.
+
+    @{
+    */
+/**
+\brief Collection of counters providing model information.
+    */
+typedef struct {
+    /** \brief Number of constants */
+    unsigned int num_constants;
+    /** \brief  Number of fixed */
+    unsigned int num_fixed;
+    /** \brief  Number of tunable */
+    unsigned int num_tunable;
+    /** \brief  Number of discrete variables */
+    unsigned int num_discrete;
+    /** \brief  Number of continuous variables */
+    unsigned int num_continuous;
+
+    /** \brief  Number of parameters*/
+    unsigned int num_parameters;
+    /** \brief  Number of calculated parameters*/
+    unsigned int num_calculated_parameters;
+    /** \brief  Number of inputs */
+    unsigned int num_inputs;
+    /** \brief  Number of outputs */
+    unsigned int num_outputs;
+    /** \brief  Number of local variables */
+    unsigned int num_local;
+    /** \brief  Number of independent variables */
+    unsigned int num_independent;
+    /** \brief  Number of structural variables */
+    unsigned int num_structural_parameters;
+
+    /** \brief  Number of float64 variables*/
+    unsigned int num_float64_vars;
+    /** \brief  Number of float32 variables*/
+    unsigned int num_float32_vars;
+
+    /** \brief  Number of int64 variables*/
+    unsigned int num_int64_vars;
+    /** \brief  Number of int32 variables*/
+    unsigned int num_int32_vars;
+    /** \brief  Number of int16 variables*/
+    unsigned int num_int16_vars;
+    /** \brief  Number of int8 variables*/
+    unsigned int num_int8_vars;
+    /** \brief  Number of int64 variables*/
+    unsigned int num_uint64_vars;
+    /** \brief  Number of uint32 variables*/
+    unsigned int num_uint32_vars;
+    /** \brief  Number of uint16 variables*/
+    unsigned int num_uint16_vars;
+    /** \brief  Number of uint8 variables*/
+    unsigned int num_uint8_vars;
+
+    /** \brief  Number of enumeration variables*/
+    unsigned int num_enum_vars;
+    /** \brief  Number of boolean variables*/
+    unsigned int num_bool_vars;
+    /** \brief  Number of string variables*/
+    unsigned int num_string_vars;
+    /** \brief  Number of binary variables*/
+    unsigned int num_binary_vars;
+    /** \brief  Number of clock variables*/
+    unsigned int num_clock_vars;
+} fmi3_import_model_counts_t;
+
+/**
+    \brief Struct for initializing #fmi3_logger_context_t.
+ */
+typedef struct {
+    const fmi3_instance_environment_t instanceEnvironment;
+    const fmi3_log_message_callback_ft logMessage;
+} fmi3_logger_context_t;
+
+/**
+    \brief Collect model information by counting the number of variables with specific properties and filling in fmi3_import_model_counts_t struct.
+    @param fmu - An fmu object as returned by fmi3_import_parse_xml().
+    @param counts - a pointer to a preallocated struct.
+*/
+FMILIB_EXPORT
+void fmi3_import_collect_model_counts(fmi3_import_t* fmu, fmi3_import_model_counts_t* counts);
+
+/**
+   \brief Transform msgIn into msgOut by expanding variable references of the form #\<Type\>\<VR\># into variable names
+   and replacing '##' with a single #.
+
+   @param fmu - An fmu object as returned by fmi3_import_parse_xml().
+   @param msgIn - Log message as produced by an FMU.
+   @param msgOut - Output message buffer.
+   @param maxMsgSize - maximum message size
+ */
+FMILIB_EXPORT
+void fmi3_import_expand_variable_references(fmi3_import_t* fmu, const char* msgIn, char* msgOut, size_t maxMsgSize);
+
+/**
+    \brief Default function for fmi3CallbackAllocateMemory.
+
+    Calls calloc from stdlib.h. Argument 'instEnv' is not used.
+*/
+FMILIB_EXPORT
+void* fmi3_callback_allocate_memory_default(fmi3_instance_environment_t instEnv, size_t nobj, size_t size);
+
+/**
+    \brief Default function for fmi3CallbackFreeMemory.
+
+    Calls free from stdlib.h. Argument 'instEnv' is not used.
+*/
+FMILIB_EXPORT
+void fmi3_callback_free_memory_default(fmi3_instance_environment_t instEnv, void* obj);
+
+/**
+ * \brief An implementation of the FMI 3.0 logger that forwards the messages to the
+ * logger function in the 'inst' object.
+ * 
+ * The 'inst' object is expected to be to a parsed FMU object object of type 'fmi3_import_t'.
+ * 
+ * The underlying logger function which is forwarded to is the same as the one in the
+ * jm_callbacks argument passed to the call to 'fmi_import_allocate_context'.
+ *
+ * Value reference name expansion is also performed before forwarding.
+ *
+ * @param inst     An 'fmi3_import_t' object retrieved from 'fmi3_import_parse_xml'.
+ * @param status   The status.
+ * @param category The category.
+ * @param message  The message.
+ */
+FMILIB_EXPORT
+void fmi3_log_forwarding(fmi3_instance_environment_t inst, fmi3_status_t status, fmi3_string_t category, fmi3_string_t message);
+
+/** \brief  Default FMI 3.0 logger may be used when instantiating FMUs */
+FMILIB_EXPORT
+void fmi3_default_callback_logger(fmi3_instance_environment_t inst, fmi3_string_t instanceName, fmi3_status_t status, fmi3_string_t category, fmi3_string_t message);
+
+/** \brief  Given ::fmi3_logger_context_t logger (fmi3_logger), the ::jm_callbacks logger may be setup to redirect the messages to the fmi3_logger.
+
+    The functions sets up the redirection. Note that the context field in ::jm_callbacks is set to point to the provided ::fmi3_logger_context_t.
+    @param cb FMI Library callbacks
+    @param loggerCallbacks FMI 3.0 standard callbacks
+*/
+FMILIB_EXPORT
+void fmi3_import_init_logger(jm_callbacks* cb, fmi3_logger_context_t* loggerCallbacks);
+
+/**
+    \brief Get variable description by variable name. Alias variable names result in the description of the alias variable.
+    @param fmu - An fmu object as returned by fmi3_import_parse_xml().
+    @param name - variable name
+    @return Description, empty string if missing description. NULL if no variable with given name exists.
+*/
+FMILIB_EXPORT
+const char* fmi3_import_get_variable_description_by_name(fmi3_import_t* fmu, const char* name);
+
+/**
+    \brief Get variable display unit by variable name. Alias variable names result in the display unit of the alias variable.
+    @param fmu - An fmu object as returned by fmi3_import_parse_xml().
+    @param name - variable name
+    @return Pointer to the display unit object if it exists; NULL if the variable does not exist or has no display unit.
+*/
+FMILIB_EXPORT
+fmi3_import_display_unit_t* fmi3_import_get_variable_display_unit_by_name(fmi3_import_t* fmu, const char* name);
+
+/**
+    \brief Checks if the clock variable is a clock to the variable.
+*/
+FMILIB_EXPORT
+fmi3_boolean_t fmi3_import_get_variable_is_clocked_by(fmi3_import_variable_t* var, fmi3_import_clock_variable_t* clock);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* FMI3_IMPORT_CONVENIENCE_H_ */

--- a/FMIL/src/Import/include/FMI3/fmi3_import_type.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import_type.h
@@ -1,0 +1,320 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_import_type.h
+*  \brief Public interface to the FMI XML C-library: variable types handling.
+*/
+
+#ifndef FMI3_IMPORT_TYPE_H_
+#define FMI3_IMPORT_TYPE_H_
+
+#include "fmi3_import_unit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+    \addtogroup fmi3_import
+    @{
+    \addtogroup fmi3_import_typedef Support for processing variable types
+    @}
+    \addtogroup fmi3_import_typedef Support for processing variable types
+  @{
+*/
+/**@name   Type definitions supporting structures*/
+/**@{ */
+/** \brief Opaque float definition object. */
+typedef struct fmi3_xml_float_typedef_t fmi3_import_float_typedef_t;
+/** \brief Opaque integer type definition object. */
+typedef struct fmi3_xml_int_typedef_t fmi3_import_int_typedef_t;
+/** \brief Opaque enumeration type definition object. */
+typedef struct fmi3_xml_enumeration_typedef_t fmi3_import_enumeration_typedef_t;
+/** \brief Opaque binary type definition object. */
+typedef struct fmi3_xml_binary_typedef_t fmi3_import_binary_typedef_t;
+/** \brief Opaque clock type definition object. */
+typedef struct fmi3_xml_clock_typedef_t fmi3_import_clock_typedef_t;
+/** \brief Opaque general variable type definition object. */
+typedef struct fmi3_xml_variable_typedef_t fmi3_import_variable_typedef_t;
+/** \brief Opaque list of the type definitions in the model */
+typedef struct fmi3_xml_type_definition_list_t fmi3_import_type_definition_list_t;
+/**@} */
+
+/** \brief Get the number of available type definitions */
+FMILIB_EXPORT size_t fmi3_import_get_type_definition_list_size(fmi3_import_type_definition_list_t* td);
+
+/** \brief Get a type definition specified by the index. Parameter 'index' does not reflect the index in the XML, but the
+        index in an internal list of type definitions.
+    @param td the type definition list object
+    @param index the index of type definition. Must be less than the number returned by # fmi3_import_get_type_definition_list
+    @return A type definition object or NULL if index is out of range.
+*/
+FMILIB_EXPORT fmi3_import_variable_typedef_t* fmi3_import_get_typedef(fmi3_import_type_definition_list_t* td, size_t index);
+
+/** \brief Get the type name*/
+FMILIB_EXPORT const char* fmi3_import_get_type_name(fmi3_import_variable_typedef_t* td);
+
+/**\brief Get type description.
+
+   Note that an empty string is returned if the attribute is not present in the XML.*/
+FMILIB_EXPORT const char* fmi3_import_get_type_description(fmi3_import_variable_typedef_t* td);
+
+/** \brief Get base type used for the type definition */
+FMILIB_EXPORT fmi3_base_type_enu_t fmi3_import_get_base_type(fmi3_import_variable_typedef_t* td);
+
+/* Boolean and String has no extra attributes -> not needed*/
+
+/** \brief Cast the general type definition object to an object with a specific base type 
+    @return Pointer to the specific type object or NULL if base type does not match.
+*/
+FMILIB_EXPORT fmi3_import_float_typedef_t* fmi3_import_get_type_as_float(fmi3_import_variable_typedef_t* td);
+
+/** \brief Cast the general type definition object to an object with a specific base type 
+    @return Pointer to the specific type object or NULL if base type does not match.
+*/
+FMILIB_EXPORT fmi3_import_int_typedef_t* fmi3_import_get_type_as_int(fmi3_import_variable_typedef_t* td);
+
+/** \brief Cast the general type definition object to an object with a specific base type 
+    @return Pointer to the specific type object or NULL if base type does not match.
+*/
+FMILIB_EXPORT fmi3_import_enumeration_typedef_t* fmi3_import_get_type_as_enum(fmi3_import_variable_typedef_t* td);
+
+/** \brief Cast the general type definition object to an object with a specific base type 
+    @return Pointer to the specific type object or NULL if base type does not match.
+*/
+FMILIB_EXPORT fmi3_import_binary_typedef_t* fmi3_import_get_type_as_binary(fmi3_import_variable_typedef_t* td);
+
+/** \brief Cast the general type definition object to an object with a specific base type 
+    @return Pointer to the specific type object or NULL if base type does not match.
+*/
+FMILIB_EXPORT fmi3_import_clock_typedef_t* fmi3_import_get_type_as_clock(fmi3_import_variable_typedef_t* td);
+
+/** \brief Get the quantity associated with the type definition.
+
+    @return The quantity, or NULL-pointer if quantity is not defined (NULL-pointer is always returned for strings and
+      booleans).
+*/
+FMILIB_EXPORT const char* fmi3_import_get_type_quantity(fmi3_import_variable_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+
+    @return Either the value specified in the XML file or negated DBL_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_type_min(fmi3_import_float_typedef_t* td);
+
+/** \brief Get maximum value for the type
+
+    @return Either the value specified in the XML file or DBL_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_type_max(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the nominal value associated with the type definition */
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_type_nominal(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the unit object associated with the type definition if any*/
+FMILIB_EXPORT fmi3_import_unit_t* fmi3_import_get_float64_type_unit(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the 'relativeQuantity' flag */
+FMILIB_EXPORT int fmi3_import_get_float64_type_is_relative_quantity(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the 'unbounded' flag */
+FMILIB_EXPORT int fmi3_import_get_float64_type_is_unbounded(fmi3_import_float_typedef_t* td);
+
+/**
+    \brief Get display unit associated with a type definition.
+    @return Display unit object of NULL if none was given.
+*/
+FMILIB_EXPORT fmi3_import_display_unit_t* fmi3_import_get_float64_type_display_unit(fmi3_import_float_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+
+    @return Either the value specified in the XML file or negated FLT_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_type_min(fmi3_import_float_typedef_t* td);
+
+/** \brief Get maximum value for the type
+
+    @return Either the value specified in the XML file or FLT_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_type_max(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the nominal value associated with the type definition */
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_type_nominal(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the unit object associated with the type definition if any*/
+FMILIB_EXPORT fmi3_import_unit_t* fmi3_import_get_float32_type_unit(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the 'relativeQuantity' flag */
+FMILIB_EXPORT int fmi3_import_get_float32_type_is_relative_quantity(fmi3_import_float_typedef_t* td);
+
+/** \brief Get the 'unbounded' flag */
+FMILIB_EXPORT int fmi3_import_get_float32_type_is_unbounded(fmi3_import_float_typedef_t* td);
+
+/**
+    \brief Get display unit associated with a type definition.
+    @return Display unit object of NULL if none was given.
+*/
+FMILIB_EXPORT fmi3_import_display_unit_t* fmi3_import_get_float32_type_display_unit(fmi3_import_float_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or INT64_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_int64_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or INT64_MIN as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_int64_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or INT32_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int32_t fmi3_import_get_int32_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or INT32_MIN as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int32_t fmi3_import_get_int32_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or INT16_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int16_t fmi3_import_get_int16_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or INT16_MIN as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int16_t fmi3_import_get_int16_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or INT8_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int8_t fmi3_import_get_int8_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or INT8_MIN as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_int8_t fmi3_import_get_int8_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or UINT64_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_uint64_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or 0
+*/
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_uint64_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or UINT32_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_uint32_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or 0
+*/
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_uint32_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or UINT16_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_uint16_t fmi3_import_get_uint16_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or 0
+*/
+FMILIB_EXPORT fmi3_uint16_t fmi3_import_get_uint16_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get maximum value for the type
+    @return Either the value specified in the XML file or UINT8_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT fmi3_uint8_t fmi3_import_get_uint8_type_max(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+    @return Either the value specified in the XML file or 0
+*/
+FMILIB_EXPORT fmi3_uint8_t fmi3_import_get_uint8_type_min(fmi3_import_int_typedef_t* td);
+
+/** \brief Get minimal value for the type.
+
+    @return Either the value specified in the XML file or 0
+*/
+FMILIB_EXPORT unsigned int fmi3_import_get_enum_type_min(fmi3_import_enumeration_typedef_t* td);
+
+/** \brief Get maximum value for the type.
+
+    @return Either the value specified in the XML file or INT_MAX as defined in <limits.h>
+*/
+FMILIB_EXPORT unsigned int fmi3_import_get_enum_type_max(fmi3_import_enumeration_typedef_t* td);
+
+/** \brief Get the number of elements in the enum */
+FMILIB_EXPORT size_t fmi3_import_get_enum_type_size(fmi3_import_enumeration_typedef_t* td);
+
+/** \brief Get an enumeration item name by index (1-based) */
+FMILIB_EXPORT const char* fmi3_import_get_enum_type_item_name(fmi3_import_enumeration_typedef_t* td, size_t item);
+
+/** \brief Get an enumeration item value by index (1-based) */
+FMILIB_EXPORT int fmi3_import_get_enum_type_item_value(fmi3_import_enumeration_typedef_t* td, size_t item);
+
+/** \brief Get an enumeration item description by index (1-based) */
+FMILIB_EXPORT const char* fmi3_import_get_enum_type_item_description(fmi3_import_enumeration_typedef_t* td, size_t item);
+
+/** \brief Get an enumeration item name for the given value */
+FMILIB_EXPORT const char* fmi3_import_get_enum_type_value_name(fmi3_import_enumeration_typedef_t* t, int value);
+
+/** \brief Get mimeType for the type */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_binary_type_mime_type(fmi3_import_binary_typedef_t* t);
+/** \brief Check if the type has the "maxSize" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_binary_type_has_max_size(fmi3_import_binary_typedef_t* t);
+/** \brief Get maxSize for the type */
+FMILIB_EXPORT size_t fmi3_import_get_binary_type_max_size(fmi3_import_binary_typedef_t* t);
+
+
+/** \brief Get canBeDeactivated for the type */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_type_can_be_deactivated(fmi3_import_clock_typedef_t* t);
+/** \brief Check if the type has the "priority" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_type_has_priority(fmi3_import_clock_typedef_t* t);
+/** \brief Get priority for the type */
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_clock_type_priority(fmi3_import_clock_typedef_t* t);
+/** \brief Get intervalVariability for the type */
+FMILIB_EXPORT fmi3_interval_variability_enu_t fmi3_import_get_clock_type_interval_variability(fmi3_import_clock_typedef_t* t);
+/** \brief Check if the type has the "intervalDecimal" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_type_has_interval_decimal(fmi3_import_clock_typedef_t* t);
+/** \brief Get intervalDecimal for the type */
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_clock_type_interval_decimal(fmi3_import_clock_typedef_t* t);
+/** \brief Get shiftDecimal for the type */
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_clock_type_shift_decimal(fmi3_import_clock_typedef_t* t);
+/** \brief Get supportsFraction for the type */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_type_supports_fraction(fmi3_import_clock_typedef_t* t);
+/** \brief Check if the type has the "resolution" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_type_has_resolution(fmi3_import_clock_typedef_t* t);
+/** \brief Get resolution for the type */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_clock_type_resolution(fmi3_import_clock_typedef_t* t);
+/** \brief Check if the type has the "intervalCounter" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_type_has_interval_counter(fmi3_import_clock_typedef_t* t);
+/** \brief Get intervalCounter for the type */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_clock_type_interval_counter(fmi3_import_clock_typedef_t* t);
+/** \brief Get shiftCounter for the type */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_clock_type_shift_counter(fmi3_import_clock_typedef_t* t);
+
+/**
+*  @}
+*/
+#ifdef __cplusplus
+}
+#endif
+#endif
+

--- a/FMIL/src/Import/include/FMI3/fmi3_import_unit.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import_unit.h
@@ -1,0 +1,153 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_import_unit.h
+*  \brief Public interface to the FMI import C-library. Handling of variable units.
+*/
+
+#ifndef FMI3_IMPORT_UNIT_H_
+#define FMI3_IMPORT_UNIT_H_
+
+#include <fmilib_config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+        /**
+    \addtogroup fmi3_import
+    @{
+    \addtogroup fmi3_import_units Functions for handling unit definitions
+    @}
+    \addtogroup fmi3_import_units Functions for handling unit definitions
+    @{
+    */
+
+/**\name Structures encapsulating unit information */
+/**@{ */
+/** \brief A variable unit defined with a unit defition */
+typedef struct fmi3_xml_unit_t fmi3_import_unit_t;
+/** \brief A display unit. */
+typedef struct fmi3_xml_display_unit_t fmi3_import_display_unit_t;
+/** \brief The list of all the unit definitions in the model */
+typedef struct fmi3_xml_unit_definition_list_t fmi3_import_unit_definition_list_t;
+/**@} */
+
+/** \brief Get the number of unit definitions. */
+FMILIB_EXPORT size_t fmi3_import_get_unit_definition_list_size(fmi3_import_unit_definition_list_t* ud);
+
+/** \brief Get a unit definition */
+FMILIB_EXPORT fmi3_import_unit_t* fmi3_import_get_unit(fmi3_import_unit_definition_list_t* ud, size_t index);
+
+/** \brief Get a unit name */
+FMILIB_EXPORT const char* fmi3_import_get_unit_name(fmi3_import_unit_t* u);
+
+/** \brief Get the number of display units associated with this unit */
+FMILIB_EXPORT size_t fmi3_import_get_unit_display_unit_list_size(fmi3_import_unit_t* u);
+
+/**
+    \brief Get fmi3_SI_base_units_Num SI base units exponents associated with the unit.
+*/
+FMILIB_EXPORT const int* fmi3_import_get_SI_unit_exponents(fmi3_import_unit_t* u);
+
+/**
+    \brief Get factor to the corresponding SI base units.
+*/
+FMILIB_EXPORT double fmi3_import_get_SI_unit_factor(fmi3_import_unit_t* u);
+
+/**
+    \brief Get offset to the corresponding SI base units.
+*/
+FMILIB_EXPORT double fmi3_import_get_SI_unit_offset(fmi3_import_unit_t* u);
+
+/**
+    \brief Convert a value with respect to the unit to the value with respect to the SI base unit.
+*/
+FMILIB_EXPORT double fmi3_import_convert_to_SI_base_unit(double v, fmi3_import_unit_t* u);
+
+/**
+    \brief Convert a value with respect to the SI base unit to the
+    value with respect to the unit.
+*/
+FMILIB_EXPORT double fmi3_import_convert_from_SI_base_unit(double v, fmi3_import_unit_t* u);
+
+/** \brief Get a display unit object by index.
+    @param u unit
+    @param index The index of display unit to be returned. Must be less than the number returned by fmi3_import_get_unit_display_unit_list_size()
+*/
+FMILIB_EXPORT fmi3_import_display_unit_t* fmi3_import_get_unit_display_unit(fmi3_import_unit_t* u, size_t index);
+
+/**
+    \brief Get unit definition for a display unit.
+*/
+FMILIB_EXPORT fmi3_import_unit_t* fmi3_import_get_base_unit(fmi3_import_display_unit_t* du);
+
+/**
+    \brief Get display unit name
+*/
+FMILIB_EXPORT const char* fmi3_import_get_display_unit_name(fmi3_import_display_unit_t* du);
+
+/**
+    \brief Get the "factor" associated with the display unit.
+*/
+FMILIB_EXPORT double fmi3_import_get_display_unit_factor(fmi3_import_display_unit_t* du);
+
+/**
+    \brief Get the "offset" associated with the display unit.
+*/
+FMILIB_EXPORT double fmi3_import_get_display_unit_offset(fmi3_import_display_unit_t* du);
+
+/**
+    \brief Get the "inverse" associated with the display unit, nonzero if inserve is set to true.
+*/
+FMILIB_EXPORT int fmi3_import_get_display_unit_inverse(fmi3_import_display_unit_t* du);
+
+/**
+    \brief Convert a value measured in "units" to a value measured with "display units"
+    @param value The value to be converted
+    @param du The display unit object
+    @param isRelativeQuantity specifies if "offset" should be incorporated into conversion
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_float64_convert_to_display_unit(fmi3_float64_t value, fmi3_import_display_unit_t* du, int isRelativeQuantity);
+
+/**
+    \brief Convert a value measured in "display units" to a value measured with "units"
+    @param value The value to be converted
+    @param du The display unit object
+    @param isRelativeQuantity specifies if "offset" should be incorporated into conversion
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_float64_convert_from_display_unit(fmi3_float64_t value, fmi3_import_display_unit_t* du, int isRelativeQuantity);
+
+/**
+    \brief Convert a value measured in "units" to a value measured with "display units"
+    @param value The value to be converted
+    @param du The display unit object
+    @param isRelativeQuantity specifies if "offset" should be incorporated into conversion
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_float32_convert_to_display_unit(fmi3_float32_t value, fmi3_import_display_unit_t* du, int isRelativeQuantity);
+
+/**
+    \brief Convert a value measured in "display units" to a value measured with "units".
+    @param value The value to be converted
+    @param du The display unit object
+    @param isRelativeQuantity specifies if "offset" should be incorporated into conversion
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_float32_convert_from_display_unit(fmi3_float32_t value, fmi3_import_display_unit_t* du, int isRelativeQuantity);
+
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/Import/include/FMI3/fmi3_import_variable.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import_variable.h
@@ -1,0 +1,624 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/**
+ * \file fmi3_import_variable.h
+ * \brief Public interface to the FMI import C-library. Handling of model variables.
+ */
+
+#ifndef FMI3_IMPORT_VARIABLE_H_
+#define FMI3_IMPORT_VARIABLE_H_
+
+#include <FMI/fmi_import_context.h>
+
+#include "fmi3_import_type.h"
+#include "fmi3_import_unit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup fmi3_import
+ * @{
+ * \addtogroup fmi3_import_variables Functions for handling variable definitions
+ * @}
+ *
+ * \addtogroup fmi3_import_variables Functions for handling variable definitions
+ * \brief All the functions in this group take a pointer to ::fmi3_import_variable_t as a parameter.
+ * A variable pointer may be obtained via a \ref fmi3_import_varlist module or via functions
+ * fmi3_import_get_variable_by_name() and fmi3_import_get_variable_by_vr().
+ * @{
+ */
+
+/**
+ * @name Scalar variable types
+ * @{
+ */
+
+/** \brief General variable type.
+ *
+ * This type is convenient to unify all the variable list operations.
+ * However, typed variables are needed to support specific attributes.
+ */
+typedef struct fmi3_xml_variable_t fmi3_import_variable_t;
+/** \brief Opaque float32 variable */
+typedef struct fmi3_xml_float32_variable_t fmi3_import_float32_variable_t;
+/** \brief Opaque float64 variable */
+typedef struct fmi3_xml_float64_variable_t fmi3_import_float64_variable_t;
+/** \brief Opaque int64 variable */
+typedef struct fmi3_xml_int64_variable_t fmi3_import_int64_variable_t;
+/** \brief Opaque int32 variable */
+typedef struct fmi3_xml_int32_variable_t fmi3_import_int32_variable_t;
+/** \brief Opaque int16 variable */
+typedef struct fmi3_xml_int16_variable_t fmi3_import_int16_variable_t;
+/** \brief Opaque int8 variable */
+typedef struct fmi3_xml_int8_variable_t fmi3_import_int8_variable_t;
+/** \brief Opaque uint64 variable */
+typedef struct fmi3_xml_uint64_variable_t fmi3_import_uint64_variable_t;
+/** \brief Opaque uint32 variable */
+typedef struct fmi3_xml_uint32_variable_t fmi3_import_uint32_variable_t;
+/** \brief Opaque uint16 variable */
+typedef struct fmi3_xml_uint16_variable_t fmi3_import_uint16_variable_t;
+/** \brief Opaque uint8 variable */
+typedef struct fmi3_xml_uint8_variable_t fmi3_import_uint8_variable_t;
+/** \brief Opaque string variable */
+typedef struct fmi3_xml_string_variable_t fmi3_import_string_variable_t;
+/** \brief Opaque enumeration variable */
+typedef struct fmi3_xml_enum_variable_t fmi3_import_enum_variable_t;
+/** \brief Opaque boolean variable */
+typedef struct fmi3_xml_bool_variable_t fmi3_import_bool_variable_t;
+/** \brief Opaque binary variable */
+typedef struct fmi3_xml_binary_variable_t fmi3_import_binary_variable_t;
+/** \brief Opaque clock variable */
+typedef struct fmi3_xml_clock_variable_t fmi3_import_clock_variable_t;
+/** \brief List of variables */
+typedef struct fmi3_import_variable_list_t fmi3_import_variable_list_t;
+/**@} */
+
+/**
+ * @name Types encapsulating alias information
+ * @{
+ */
+/** \brief List of the alias variables for a non-alias variable */
+typedef struct fmi3_xml_alias_variable_list_t fmi3_import_alias_variable_list_t;
+/** \brief Opaque alias variable. Only contains the alias-specific information. */
+typedef struct fmi3_xml_alias_variable_t fmi3_import_alias_variable_t;
+/** @} */
+
+/**
+ * @name Types encapsulating variable dimension information
+ * @{
+ */
+/** \brief Opaque data type for dimension handling */
+typedef struct fmi3_xml_dimension_t fmi3_import_dimension_t;
+/** \brief Opaque data type for dimension list handling*/
+typedef struct fmi3_xml_dimension_list_t fmi3_import_dimension_list_t;
+/** @} */
+
+
+/** \brief Get the variable name */
+FMILIB_EXPORT const char* fmi3_import_get_variable_name(fmi3_import_variable_t* v);
+
+/** \brief Check if variable has a description. */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_variable_has_description(fmi3_import_variable_t* v);
+
+/** \brief Get variable description.
+    @return Description string or empty string if no description in the XML file was given.
+*/
+FMILIB_EXPORT const char* fmi3_import_get_variable_description(fmi3_import_variable_t* v);
+
+/** \brief Get variable value reference */
+FMILIB_EXPORT fmi3_value_reference_t fmi3_import_get_variable_vr(fmi3_import_variable_t* v);
+
+/** \brief For scalar variable gives the type definition is present
+    @return Pointer of a type #fmi3_import_variable_typedef_t object or NULL of not present.
+*/
+FMILIB_EXPORT fmi3_import_variable_typedef_t* fmi3_import_get_variable_declared_type(fmi3_import_variable_t* v);
+
+/** \brief Get variable base type */
+FMILIB_EXPORT fmi3_base_type_enu_t fmi3_import_get_variable_base_type(fmi3_import_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_float64_t* fmi3_import_get_float64_variable_start_array(fmi3_import_float64_variable_t* v);
+
+/** \brief Get the start values of an array variable.
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_float32_t* fmi3_import_get_float32_variable_start_array(fmi3_import_float32_variable_t* v);
+
+/** \brief Get the reinit values of a variable. */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_float64_variable_reinit(fmi3_import_float64_variable_t* v);
+
+/** \brief Get the reinit values of a variable. */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_float32_variable_reinit(fmi3_import_float32_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_int64_t* fmi3_import_get_int64_variable_start_array(fmi3_import_int64_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_int32_t* fmi3_import_get_int32_variable_start_array(fmi3_import_int32_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_int16_t* fmi3_import_get_int16_variable_start_array(fmi3_import_int16_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_int8_t* fmi3_import_get_int8_variable_start_array(fmi3_import_int8_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_uint64_t* fmi3_import_get_uint64_variable_start_array(fmi3_import_uint64_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_uint32_t* fmi3_import_get_uint32_variable_start_array(fmi3_import_uint32_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_uint16_t* fmi3_import_get_uint16_variable_start_array(fmi3_import_uint16_variable_t* v);
+
+/** \brief Get the start values of an array variable
+ * @return Pointer to array with start values. Total length of array is given by array dimensions.
+ */
+FMILIB_EXPORT fmi3_uint8_t* fmi3_import_get_uint8_variable_start_array(fmi3_import_uint8_variable_t* v);
+
+/**   \brief Check if the variable is an array.
+    @return True if array, false if scalar.
+*/
+FMILIB_EXPORT int fmi3_import_variable_is_array(fmi3_import_variable_t* v);
+
+/** \brief Check if the variable has "start" attribute */
+FMILIB_EXPORT int fmi3_import_get_variable_has_start(fmi3_import_variable_t* v);
+
+/** \brief Get variability attribute */
+FMILIB_EXPORT fmi3_variability_enu_t fmi3_import_get_variable_variability(fmi3_import_variable_t* v);
+
+/** \brief Get causality attribute */
+FMILIB_EXPORT fmi3_causality_enu_t fmi3_import_get_variable_causality(fmi3_import_variable_t* v);
+
+/** \brief Get initial attribute */
+FMILIB_EXPORT fmi3_initial_enu_t fmi3_import_get_variable_initial(fmi3_import_variable_t* );
+
+/**
+    \brief Get the variable that holds the previous value of this variable, if defined.
+
+    @return If this variable is a discrete-time state, return the variable holds its previous value;
+            NULL otherwise.
+*/
+FMILIB_EXPORT fmi3_import_variable_t* fmi3_import_get_variable_previous(fmi3_import_variable_t* v);
+
+/** \brief Get the canHandleMultipleSetPerTimeInstant flag for a variable.
+
+    @return For inputs: If false, then only one fmiSetXXX call is allowed at
+    one super dense time instant. In other words, this input is not allowed to
+    appear in an algebraic loop.
+*/
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_variable_can_handle_multiple_set_per_time_instant(fmi3_import_variable_t* v);
+
+/** \brief Get the intermediateUpdate flag for a variable.
+
+    @return If true, the variable can be accessed in Intermediate Update Mode
+*/
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_variable_intermediate_update(fmi3_import_variable_t* v);
+
+/** \brief Check if the variable has the "clocks" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_variable_is_clocked(fmi3_import_variable_t* v);
+
+/** \brief Get a list of variables referenced in the 'clock' attribute.
+ *  Note that the caller is responsible for deallocating the list.
+ *
+ *  @return The array of value references.
+ */
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_variable_clocks(fmi3_import_t* fmu, fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_float64_variable_t* fmi3_import_get_variable_as_float64(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_float32_variable_t* fmi3_import_get_variable_as_float32(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_int64_variable_t* fmi3_import_get_variable_as_int64(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_int32_variable_t* fmi3_import_get_variable_as_int32(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_int16_variable_t* fmi3_import_get_variable_as_int16(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_int8_variable_t* fmi3_import_get_variable_as_int8(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_uint64_variable_t* fmi3_import_get_variable_as_uint64(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_uint32_variable_t* fmi3_import_get_variable_as_uint32(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_uint16_variable_t* fmi3_import_get_variable_as_uint16(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_uint8_variable_t* fmi3_import_get_variable_as_uint8(fmi3_import_variable_t* v);
+
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_enum_variable_t* fmi3_import_get_variable_as_enum(fmi3_import_variable_t* v);
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_string_variable_t* fmi3_import_get_variable_as_string(fmi3_import_variable_t* v);
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_bool_variable_t* fmi3_import_get_variable_as_boolean(fmi3_import_variable_t* v);
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_binary_variable_t* fmi3_import_get_variable_as_binary(fmi3_import_variable_t* v);
+/** \brief Cast general variable to a one with the specific type
+
+    @return Typed object or NULL if base type does not match
+*/
+FMILIB_EXPORT fmi3_import_clock_variable_t* fmi3_import_get_variable_as_clock(fmi3_import_variable_t* v);
+
+/** \brief Get minimal value for the variable.
+
+    @return Either the value specified in the XML file or negated FLT_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_variable_min(fmi3_import_float32_variable_t* v);
+
+/** \brief Get maximum value for the variable.
+
+    @return Either the value specified in the XML file or FLT_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_variable_max(fmi3_import_float32_variable_t* v);
+
+/** \brief Get nominal value for the variable.
+
+    @return The "start" attribute as specified in the XML file or variable nominal value.
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_variable_nominal(fmi3_import_float32_variable_t* v);
+
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_float32_variable_quantity(fmi3_import_float32_variable_t* v);
+
+/** \brief Get associated "unit" object if any */
+FMILIB_EXPORT fmi3_import_unit_t* fmi3_import_get_float32_variable_unit(fmi3_import_float32_variable_t* v);
+
+/** \brief Get associated "display unit" object if any */
+FMILIB_EXPORT fmi3_import_display_unit_t* fmi3_import_get_float32_variable_display_unit(fmi3_import_float32_variable_t* v);
+
+/**
+    \brief Get the variable that this is a derivative of, if defined.
+
+    @return If this variable is a derivative, return the variable that it is a derivative of;
+            NULL otherwise.
+*/
+FMILIB_EXPORT fmi3_import_float32_variable_t* fmi3_import_get_float32_variable_derivative_of(fmi3_import_float32_variable_t* v);
+
+/**
+    \brief Get the variable start attribute.
+
+    @return The "start" attribute as specified in the XML file or variable nominal value.
+*/
+FMILIB_EXPORT fmi3_float32_t fmi3_import_get_float32_variable_start(fmi3_import_float32_variable_t* v);
+
+/** \brief Get the variable "relativeQuantity" attribute.
+    @return The "relativeQuantity" attribute as specified in the XML file. False if undefined.
+*/
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_float32_variable_relative_quantity(fmi3_import_float32_variable_t* v);
+
+/** \brief Get the variable "unbounded" attribute.
+    @return The "unbounded" attribute as specified in the XML file. False if undefined.
+*/
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_float32_variable_unbounded(fmi3_import_float32_variable_t* v);
+
+/** \brief Get minimal value for the variable.
+
+    @return Either the value specified in the XML file or negated DBL_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_variable_min(fmi3_import_float64_variable_t* v);
+
+/** \brief Get maximum value for the variable.
+
+    @return Either the value specified in the XML file or DBL_MAX as defined in <float.h>
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_variable_max(fmi3_import_float64_variable_t* v);
+
+/** \brief Get nominal value for the variable.
+
+    @return The "start" attribute as specified in the XML file or variable nominal value.
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_variable_nominal(fmi3_import_float64_variable_t* v);
+
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_float64_variable_quantity(fmi3_import_float64_variable_t* v);
+
+/**
+    \brief Get the variable start attribute.
+
+    @return The "start" attribute as specified in the XML file or variable nominal value.
+*/
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_float64_variable_start(fmi3_import_float64_variable_t* v);
+
+/** \brief Get associated "unit" object if any */
+FMILIB_EXPORT fmi3_import_unit_t* fmi3_import_get_float64_variable_unit(fmi3_import_float64_variable_t* v);
+
+/** \brief Get associated "display unit" object if any */
+FMILIB_EXPORT fmi3_import_display_unit_t* fmi3_import_get_float64_variable_display_unit(fmi3_import_float64_variable_t* v);
+
+/**
+    \brief Get the variable that this is a derivative of, if defined.
+
+    @return If this variable is a derivative, return the variable that it is a derivative of;
+            NULL otherwise.
+*/
+FMILIB_EXPORT fmi3_import_float64_variable_t* fmi3_import_get_float64_variable_derivative_of(fmi3_import_float64_variable_t* v);
+
+/** \brief Get the variable "relativeQuantity" attribute.
+    @return The "relativeQuantity" attribute as specified in the XML file. False if undefined.
+*/
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_float64_variable_relative_quantity(fmi3_import_float64_variable_t* v);
+
+/** \brief Get the variable "unbounded" attribute.
+    @return The "unbounded" attribute as specified in the XML file. False if undefined.
+*/
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_float64_variable_unbounded(fmi3_import_float64_variable_t* v);
+
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_string_variable_start(fmi3_import_string_variable_t* v);
+
+/** \brief Get start values for the array variable */
+FMILIB_EXPORT fmi3_string_t* fmi3_import_get_string_variable_start_array(fmi3_import_string_variable_t* v);
+
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_boolean_variable_start(fmi3_import_bool_variable_t* v);
+
+/** \brief Get the start values of an array variable
+    @return Pointer to array with start values. Total length of array is given by product of the dimensions given by
+        #fmi3_import_get_variable_dimension_list. FMI Library handles memory for the array.
+*/
+FMILIB_EXPORT fmi3_boolean_t* fmi3_import_get_boolean_variable_start_array(fmi3_import_bool_variable_t* v);
+
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_int64_variable_quantity(fmi3_import_int64_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_int32_variable_quantity(fmi3_import_int32_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_int16_variable_quantity(fmi3_import_int16_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_int8_variable_quantity(fmi3_import_int8_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_uint64_variable_quantity(fmi3_import_uint64_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_uint32_variable_quantity(fmi3_import_uint32_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_uint16_variable_quantity(fmi3_import_uint16_variable_t* v);
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_uint8_variable_quantity(fmi3_import_uint8_variable_t* v);
+
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_int64_variable_min(fmi3_import_int64_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_int32_t fmi3_import_get_int32_variable_min(fmi3_import_int32_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_int16_t fmi3_import_get_int16_variable_min(fmi3_import_int16_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_int8_t fmi3_import_get_int8_variable_min(fmi3_import_int8_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_uint64_variable_min(fmi3_import_uint64_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_uint32_variable_min(fmi3_import_uint32_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_uint16_t fmi3_import_get_uint16_variable_min(fmi3_import_uint16_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_uint8_t fmi3_import_get_uint8_variable_min(fmi3_import_uint8_variable_t* v);
+
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_int64_variable_max(fmi3_import_int64_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_int32_t fmi3_import_get_int32_variable_max(fmi3_import_int32_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_int16_t fmi3_import_get_int16_variable_max(fmi3_import_int16_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_int8_t fmi3_import_get_int8_variable_max(fmi3_import_int8_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_uint64_variable_max(fmi3_import_uint64_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_uint32_variable_max(fmi3_import_uint32_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_uint16_t fmi3_import_get_uint16_variable_max(fmi3_import_uint16_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_uint8_t fmi3_import_get_uint8_variable_max(fmi3_import_uint8_variable_t* v);
+
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_int64_variable_start(fmi3_import_int64_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_int32_t fmi3_import_get_int32_variable_start(fmi3_import_int32_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_int16_t fmi3_import_get_int16_variable_start(fmi3_import_int16_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_int8_t fmi3_import_get_int8_variable_start(fmi3_import_int8_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_uint64_variable_start(fmi3_import_uint64_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_uint32_variable_start(fmi3_import_uint32_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_uint16_t fmi3_import_get_uint16_variable_start(fmi3_import_uint16_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_uint8_t fmi3_import_get_uint8_variable_start(fmi3_import_uint8_variable_t* v);
+
+/** \brief Get "quantity" attribute if defined, else NULL-pointer. */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_enum_variable_quantity(fmi3_import_enum_variable_t* v);
+/** \brief Get start value for the variable*/
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_enum_variable_start(fmi3_import_enum_variable_t* v);
+/** \brief Get start value for the array variable*/
+FMILIB_EXPORT fmi3_int64_t* fmi3_import_get_enum_variable_start_array(fmi3_import_enum_variable_t* v);
+/** \brief Get minimal value for the variable */
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_enum_variable_min(fmi3_import_enum_variable_t* v);
+/** \brief Get max value for the variable */
+FMILIB_EXPORT fmi3_int64_t fmi3_import_get_enum_variable_max(fmi3_import_enum_variable_t* v);
+
+/** \brief Get the length of the binary variable's start value (which is an array). */
+FMILIB_EXPORT size_t fmi3_import_get_binary_variable_start_size(fmi3_import_binary_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_binary_t fmi3_import_get_binary_variable_start(fmi3_import_binary_variable_t* v);
+/** \brief Get start value for the variable */
+FMILIB_EXPORT fmi3_binary_t* fmi3_import_get_binary_variable_start_array(fmi3_import_binary_variable_t* v);
+/** \brief Get the size of each start value for the variable */
+FMILIB_EXPORT size_t* fmi3_import_get_binary_variable_start_array_sizes(fmi3_import_binary_variable_t* v);
+/** \brief Get the number of values in the start array for the variable */
+FMILIB_EXPORT size_t fmi3_import_get_binary_variable_start_array_size(fmi3_import_binary_variable_t* v);
+/** \brief Get mimeType for the variable */
+FMILIB_EXPORT fmi3_string_t fmi3_import_get_binary_variable_mime_type(fmi3_import_binary_variable_t* v);
+/** \brief Check if the variable has the "maxSize" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_binary_variable_has_max_size(fmi3_import_binary_variable_t* v);
+/** \brief Get maxSize for the variable */
+FMILIB_EXPORT size_t fmi3_import_get_binary_variable_max_size(fmi3_import_binary_variable_t* v);
+
+/** \brief Get canBeDeactivated for the variable */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_variable_can_be_deactivated(fmi3_import_clock_variable_t* v);
+/** \brief Check if the variable has the "priority" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_variable_has_priority(fmi3_import_clock_variable_t* v);
+/** \brief Get priority for the variable */
+FMILIB_EXPORT fmi3_uint32_t fmi3_import_get_clock_variable_priority(fmi3_import_clock_variable_t* v);
+/** \brief Get intervalVariability for the variable */
+FMILIB_EXPORT fmi3_interval_variability_enu_t fmi3_import_get_clock_variable_interval_variability(fmi3_import_clock_variable_t* v);
+/** \brief Check if the variable has the "intervalDecimal" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_variable_has_interval_decimal(fmi3_import_clock_variable_t* v);
+/** \brief Get intervalDecimal for the variable */
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_clock_variable_interval_decimal(fmi3_import_clock_variable_t* v);
+/** \brief Get shiftDecimal for the variable */
+FMILIB_EXPORT fmi3_float64_t fmi3_import_get_clock_variable_shift_decimal(fmi3_import_clock_variable_t* v);
+/** \brief Get supportsFraction for the variable */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_variable_supports_fraction(fmi3_import_clock_variable_t* v);
+/** \brief Check if the variable has the "resolution" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_variable_has_resolution(fmi3_import_clock_variable_t* v);
+/** \brief Get resolution for the variable */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_clock_variable_resolution(fmi3_import_clock_variable_t* v);
+/** \brief Check if the variable has the "intervalCounter" attribute */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_clock_variable_has_interval_counter(fmi3_import_clock_variable_t* v);
+/** \brief Get intervalCounter for the variable */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_clock_variable_interval_counter(fmi3_import_clock_variable_t* v);
+/** \brief Get shiftCounter for the variable */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_clock_variable_shift_counter(fmi3_import_clock_variable_t* v);
+
+/** \brief Get the original index in xml of the variable */
+FMILIB_EXPORT size_t fmi3_import_get_variable_original_order(fmi3_import_variable_t* v);
+
+/** \brief Check if the variable has aliases */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_variable_has_alias(fmi3_import_variable_t* v);
+/** \brief Get the alias variables. */
+FMILIB_EXPORT fmi3_import_alias_variable_list_t* fmi3_import_get_variable_alias_list(fmi3_import_variable_t* v);
+/** \brief Get the number of alias variables. */
+FMILIB_EXPORT size_t fmi3_import_get_alias_variable_list_size(fmi3_import_alias_variable_list_t* aliases);
+/** \brief Get the alias from the list at the given index. */
+FMILIB_EXPORT fmi3_import_alias_variable_t* fmi3_import_get_alias(fmi3_import_alias_variable_list_t* aliases, size_t index);
+
+/** \brief Get name for the alias variable. */
+FMILIB_EXPORT const char* fmi3_import_get_alias_variable_name(fmi3_import_alias_variable_t* alias);
+/** \brief Check if an alias variable has a description. */
+FMILIB_EXPORT fmi3_boolean_t fmi3_import_get_alias_variable_has_description(fmi3_import_alias_variable_t* alias);
+/** \brief Get the description for the alias variable, empty string if missing */
+FMILIB_EXPORT const char* fmi3_import_get_alias_variable_description(fmi3_import_alias_variable_t* alias);
+/** \brief Get the displayUnit for the alias variable, or NULL if not defined. */
+FMILIB_EXPORT fmi3_import_display_unit_t* fmi3_import_get_alias_variable_display_unit(fmi3_import_alias_variable_t* alias);
+
+/** @} */
+
+/**
+    \addtogroup fmi3_import 
+    @{
+       \defgroup fmi3_import_dim Handling of dimensions
+    @}
+ */
+
+/**
+    \addtogroup fmi3_import_dim
+    \brief Handling of dimensions for array variables.
+    @{ 
+ */
+
+/** \brief Get a list of the variable's array dimensions.
+    @return list of array dimensions for a variable.
+*/
+FMILIB_EXPORT fmi3_import_dimension_list_t* fmi3_import_get_variable_dimension_list(fmi3_import_variable_t* v);
+
+/** \brief  Get number of dimensions in a list */
+FMILIB_EXPORT size_t fmi3_import_get_dimension_list_size(fmi3_import_dimension_list_t* dl);
+
+/** \brief Get a single dimension from a list */
+FMILIB_EXPORT fmi3_import_dimension_t* fmi3_import_get_dimension(fmi3_import_dimension_list_t* dl, size_t index);
+
+/** \brief Checks if the dimension contains the valueReference attribute */
+FMILIB_EXPORT int fmi3_import_get_dimension_has_vr(fmi3_import_dimension_t* dim);
+
+/** \brief Checks if the dimension contains the start attribute */
+FMILIB_EXPORT int fmi3_import_get_dimension_has_start(fmi3_import_dimension_t* dim);
+
+/** \brief Get the start value of the dimension */
+FMILIB_EXPORT fmi3_uint64_t fmi3_import_get_dimension_start(fmi3_import_dimension_t* dim);
+
+/** \brief Get the valueReference of the dimension */
+FMILIB_EXPORT fmi3_value_reference_t fmi3_import_get_dimension_vr(fmi3_import_dimension_t* dim);
+
+/** @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/Import/include/FMI3/fmi3_import_variable_list.h
+++ b/FMIL/src/Import/include/FMI3/fmi3_import_variable_list.h
@@ -1,0 +1,130 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_import_variable_list.h
+*  \brief Public interface to the FMI XML C-library. Handling of variable lists.
+*/
+
+#ifndef FMI3_IMPORT_VARIABLELIST_H_
+#define FMI3_IMPORT_VARIABLELIST_H_
+
+#include "fmi3_import_variable.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ \addtogroup  fmi3_import
+ @{
+    \defgroup  fmi3_import_varlist Handling of variable lists
+ @}
+*/
+
+/** \addtogroup  fmi3_import_varlist
+*  \brief Variable lists are provided to handle sets of variables.
+*
+* Note that variable lists are allocated dynamically and must be freed when not needed any longer.
+ @{ 
+*/
+
+/** \brief Callback function typedef for the fmiFilterVariables. 
+
+The function should return 0 to prevent a variable from coming to the output list. */
+typedef int (*fmi3_import_variable_filter_function_ft)(fmi3_import_variable_t*vl, void* data);
+
+/** \brief Allocate an empty list */
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_alloc_variable_list(fmi3_import_t* fmu, size_t size);
+
+/**  \brief Free a variable list. Note that variable lists are allocated dynamically and must be freed when not needed any longer 
+    @param vl A variable list.
+*/
+FMILIB_EXPORT void fmi3_import_free_variable_list(fmi3_import_variable_list_t* vl);
+
+/** \brief Make a copy of the list.
+    @param vl A variable list.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_clone_variable_list(fmi3_import_variable_list_t* vl);
+
+/** \brief  Get number of variables in a list */
+FMILIB_EXPORT size_t  fmi3_import_get_variable_list_size(fmi3_import_variable_list_t* vl);
+
+/** \brief  Get a pointer to the list of the value references for all the variables */
+FMILIB_EXPORT const fmi3_value_reference_t* fmi3_import_get_value_reference_list(fmi3_import_variable_list_t* vl);
+
+/** \brief Get a single variable from the list*/
+FMILIB_EXPORT fmi3_import_variable_t* fmi3_import_get_variable(fmi3_import_variable_list_t* vl, size_t index);
+
+/** \name Operations on variable lists. Every operation creates a new list. 
+@{
+*/
+/** \brief Select sub-lists.
+    @param vl A variable list.
+    @param fromIndex Zero based start index, inclusive.
+    @param toIndex Zero based end index, inclusive.
+    @return A sublist. NULL is returned if toIndex is less than fromIndex or is larger than the list size or if memory allocation failed.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_get_sublist(fmi3_import_variable_list_t* vl, size_t fromIndex, size_t toIndex);
+
+/** \brief Call the provided 'filter' function on every variable in the list and create a new list.
+  
+    @param vl A variable list.
+    @param filter A filter function according to ::fmi3_import_variable_filter_function_ft.
+    @param context A parameter to be forwarded to the filter function.
+    @return A sub-list with the variables for which filter returned non-zero value. */
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_filter_variables(fmi3_import_variable_list_t* vl, fmi3_import_variable_filter_function_ft filter, void* context);
+
+/** \brief Create a new variable list by concatenating two lists.
+  
+    @param a A variable list.
+    @param b A variable list.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_join_var_list(fmi3_import_variable_list_t* a, fmi3_import_variable_list_t* b);
+
+
+/** \brief Append a variable to the variable list.
+  
+    @param vl A variable list.
+    @param v A variable.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_append_to_var_list(fmi3_import_variable_list_t* vl, fmi3_import_variable_t* v);
+
+/** \brief Prepend a variable to the variable list.
+  
+    @param vl A variable list.
+    @param v A variable.
+*/
+FMILIB_EXPORT fmi3_import_variable_list_t* fmi3_import_prepend_to_var_list(fmi3_import_variable_list_t* vl, fmi3_import_variable_t* v);
+
+/** \brief Add a variable to a variable list.
+  
+    @param vl A variable list.
+    @param v A variable.
+
+    TODO: This one functions the same as fmi3_import_append_to_var_list, but without creating a new list?
+*/
+FMILIB_EXPORT jm_status_enu_t fmi3_import_var_list_push_back(fmi3_import_variable_list_t* vl, fmi3_import_variable_t* v);
+/**
+  @}
+ */
+
+/**
+  @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/Util/include/FMI/fmi_util_options.h
+++ b/FMIL/src/Util/include/FMI/fmi_util_options.h
@@ -1,0 +1,35 @@
+/*
+    Copyright (C) 2021 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI_UTIL_OPTIONS_H
+#define FMI_UTIL_OPTIONS_H
+
+#include <JM/jm_callbacks.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct fmi_util_options_t fmi_util_options_t;
+
+fmi_util_options_t* fmi_util_allocate_options(jm_callbacks* cb);
+
+void fmi_util_free_options(jm_callbacks* cb, fmi_util_options_t* opts);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMI_UTIL_OPTIONS_H */

--- a/FMIL/src/Util/include/FMI2/fmi2_function_types.h
+++ b/FMIL/src/Util/include/FMI2/fmi2_function_types.h
@@ -1,0 +1,194 @@
+/*
+    Copyright (C) 2012 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+     This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef _FMI2_FUNCTION_TYPES_H_
+#define _FMI2_FUNCTION_TYPES_H_
+
+#include <string.h>
+#include <fmilib_config.h>
+
+#include "fmi2_types.h"
+/**    \file fmi2_function_types.h
+    Mapping for the standard FMI 2.0 functions into fmi2_ namespace.
+
+    \addtogroup fmi2_utils
+    @{
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* make sure all compiler use the same alignment policies for structures */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(push,8)
+#endif
+
+
+/** FMI 2.0 status codes */
+typedef enum {
+    fmi2_status_ok,
+    fmi2_status_warning,
+    fmi2_status_discard,
+    fmi2_status_error,
+    fmi2_status_fatal,
+    fmi2_status_pending
+} fmi2_status_t;
+
+typedef enum {
+    fmi2_model_exchange,
+    fmi2_cosimulation
+} fmi2_type_t;
+
+
+/* Type definitions */
+
+/** FMI 2.0 logger function type */
+typedef void  (*fmi2_callback_logger_ft)        (fmi2_component_environment_t env, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, ...);
+/** FMI 2.0 allocate memory function type */
+typedef void* (*fmi2_callback_allocate_memory_ft)(size_t nobj, size_t size);
+/** FMI 2.0 free memory  function type */
+typedef void  (*fmi2_callback_free_memory_ft)    (void* obj);
+/** FMI 2.0 step finished callback function type */
+typedef void  (*fmi2_step_finished_ft)          (fmi2_component_environment_t env, fmi2_status_t status);
+
+/** The FMI 2.0 callbacks */
+typedef struct {
+    fmi2_callback_logger_ft         logger;
+    fmi2_callback_allocate_memory_ft allocateMemory;
+    fmi2_callback_free_memory_ft     freeMemory;
+    fmi2_step_finished_ft           stepFinished;
+    fmi2_component_environment_t    componentEnvironment;
+} fmi2_callback_functions_t;
+
+/** Event info structure as used in FMI 2.0 ME */
+/* TODO: reuse from fmiFunctions.h */
+typedef struct {
+    fmi2_boolean_t newDiscreteStatesNeeded;
+    fmi2_boolean_t terminateSimulation;
+    fmi2_boolean_t nominalsOfContinuousStatesChanged;
+    fmi2_boolean_t valuesOfContinuousStatesChanged;
+    fmi2_boolean_t nextEventTimeDefined;
+    fmi2_real_t    nextEventTime;
+} fmi2_event_info_t;
+
+/** Co-simulation status for FMI 2.0 CS */
+/* TODO: reuse from fmiFunctions.h */
+typedef enum {
+    fmi2_do_step_status,
+    fmi2_pending_status,
+    fmi2_last_successful_time,
+    fmi2_terminated
+} fmi2_status_kind_t;
+
+
+
+/* reset alignment policy to the one set before reading this file */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(pop)
+#endif
+
+/* Define fmi function pointer types to simplify dynamic loading */
+
+/***************************************************
+Types for Common Functions
+****************************************************/
+
+/* Inquire version numbers of header files and setting logging status */
+   typedef const char* (*fmi2_get_types_platform_ft)();
+   typedef const char* (*fmi2_get_version_ft)();
+   typedef fmi2_status_t   (*fmi2_set_debug_logging_ft)(fmi2_component_t, fmi2_boolean_t,size_t nCategories, const fmi2_string_t categories[]);
+
+/* Creation and destruction of fmu instances and setting debug status */
+   typedef fmi2_component_t (*fmi2_instantiate_ft) (fmi2_string_t, fmi2_type_t, fmi2_string_t, fmi2_string_t, const fmi2_callback_functions_t*, fmi2_boolean_t, fmi2_boolean_t);
+   typedef void         (*fmi2_free_instance_ft)(fmi2_component_t);
+
+/* Enter and exit initialization mode, terminate and reset */
+   typedef fmi2_status_t (*fmi2_setup_experiment_ft)          (fmi2_component_t, fmi2_boolean_t, fmi2_real_t, fmi2_real_t, fmi2_boolean_t, fmi2_real_t);
+   typedef fmi2_status_t (*fmi2_enter_initialization_mode_ft) (fmi2_component_t);
+   typedef fmi2_status_t (*fmi2_exit_initialization_mode_ft)  (fmi2_component_t);
+   typedef fmi2_status_t (*fmi2_terminate_ft)              (fmi2_component_t);
+   typedef fmi2_status_t (*fmi2_reset_ft)     (fmi2_component_t);
+
+/* Getting and setting variable values */
+   typedef fmi2_status_t (*fmi2_get_real_ft)   (fmi2_component_t, const fmi2_value_reference_t[], size_t, fmi2_real_t   []);
+   typedef fmi2_status_t (*fmi2_get_integer_ft)(fmi2_component_t, const fmi2_value_reference_t[], size_t, fmi2_integer_t[]);
+   typedef fmi2_status_t (*fmi2_get_boolean_ft)(fmi2_component_t, const fmi2_value_reference_t[], size_t, fmi2_boolean_t[]);
+   typedef fmi2_status_t (*fmi2_get_string_ft) (fmi2_component_t, const fmi2_value_reference_t[], size_t, fmi2_string_t []);
+
+   typedef fmi2_status_t (*fmi2_set_real_ft)   (fmi2_component_t, const fmi2_value_reference_t[], size_t, const fmi2_real_t   []);
+   typedef fmi2_status_t (*fmi2_set_integer_ft)(fmi2_component_t, const fmi2_value_reference_t[], size_t, const fmi2_integer_t[]);
+   typedef fmi2_status_t (*fmi2_set_boolean_ft)(fmi2_component_t, const fmi2_value_reference_t[], size_t, const fmi2_boolean_t[]);
+   typedef fmi2_status_t (*fmi2_set_string_ft) (fmi2_component_t, const fmi2_value_reference_t[], size_t, const fmi2_string_t []);
+
+/* Getting and setting the internal _fmu_ state */
+   typedef fmi2_status_t (*fmi2_get_fmu_state_ft)           (fmi2_component_t, fmi2_FMU_state_t*);
+   typedef fmi2_status_t (*fmi2_set_fmu_state_ft)           (fmi2_component_t, fmi2_FMU_state_t);
+   typedef fmi2_status_t (*fmi2_free_fmu_state_ft)          (fmi2_component_t, fmi2_FMU_state_t*);
+   typedef fmi2_status_t (*fmi2_serialized_fmu_state_size_ft)(fmi2_component_t, fmi2_FMU_state_t, size_t*);
+   typedef fmi2_status_t (*fmi2_serialize_fmu_state_ft)     (fmi2_component_t, fmi2_FMU_state_t, fmi2_byte_t[], size_t);
+   typedef fmi2_status_t (*fmi2_de_serialize_fmu_state_ft)   (fmi2_component_t, const fmi2_byte_t[], size_t, fmi2_FMU_state_t*);
+
+/* Getting directional derivatives */
+   typedef fmi2_status_t (*fmi2_get_directional_derivative_ft)(fmi2_component_t, const fmi2_value_reference_t[], size_t,
+                                                                   const fmi2_value_reference_t[], size_t,
+                                                                   const fmi2_real_t[], fmi2_real_t[]);
+
+/***************************************************
+Types for Functions for FMI for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+   typedef fmi2_status_t (*fmi2_enter_event_mode_ft)          (fmi2_component_t);
+   typedef fmi2_status_t (*fmi2_new_discrete_states_ft)       (fmi2_component_t, fmi2_event_info_t*);
+   typedef fmi2_status_t (*fmi2_enter_continuous_time_mode_ft)(fmi2_component_t);
+   typedef fmi2_status_t (*fmi2_completed_integrator_step_ft) (fmi2_component_t, fmi2_boolean_t, fmi2_boolean_t*, fmi2_boolean_t*);
+
+/* Providing independent variables and re-initialization of caching */
+   typedef fmi2_status_t (*fmi2_set_time_ft)                (fmi2_component_t, fmi2_real_t);
+   typedef fmi2_status_t (*fmi2_set_continuous_states_ft)    (fmi2_component_t, const fmi2_real_t[], size_t);
+
+/* Evaluation of the model equations */
+   typedef fmi2_status_t (*fmi2_get_derivatives_ft)            (fmi2_component_t, fmi2_real_t[], size_t);
+   typedef fmi2_status_t (*fmi2_get_event_indicators_ft)        (fmi2_component_t, fmi2_real_t[], size_t);
+   typedef fmi2_status_t (*fmi2_get_continuous_states_ft)       (fmi2_component_t, fmi2_real_t[], size_t);
+   typedef fmi2_status_t (*fmi2_get_nominals_of_continuous_states_ft)(fmi2_component_t, fmi2_real_t[], size_t);
+
+
+/***************************************************
+Types for_functions for FMI for Co-_simulation
+****************************************************/
+
+/* Simulating the slave */
+   typedef fmi2_status_t (*fmi2_set_real_input_derivatives_ft) (fmi2_component_t, const fmi2_value_reference_t [], size_t, const fmi2_integer_t [], const fmi2_real_t []);
+   typedef fmi2_status_t (*fmi2_get_real_output_derivatives_ft)(fmi2_component_t, const fmi2_value_reference_t [], size_t, const fmi2_integer_t [], fmi2_real_t []);
+
+   typedef fmi2_status_t (*fmi2_do_step_ft)     (fmi2_component_t, fmi2_real_t, fmi2_real_t, fmi2_boolean_t);
+   typedef fmi2_status_t (*fmi2_cancel_step_ft) (fmi2_component_t);
+
+/* Inquire slave status */
+   typedef fmi2_status_t (*fmi2_get_status_ft)       (fmi2_component_t, const fmi2_status_kind_t, fmi2_status_t* );
+   typedef fmi2_status_t (*fmi2_get_real_status_ft)   (fmi2_component_t, const fmi2_status_kind_t, fmi2_real_t*   );
+   typedef fmi2_status_t (*fmi2_get_integer_status_ft)(fmi2_component_t, const fmi2_status_kind_t, fmi2_integer_t*);
+   typedef fmi2_status_t (*fmi2_get_boolean_status_ft)(fmi2_component_t, const fmi2_status_kind_t, fmi2_boolean_t*);
+   typedef fmi2_status_t (*fmi2_get_string_status_ft) (fmi2_component_t, const fmi2_status_kind_t, fmi2_string_t* );
+
+/**    @}
+*/
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi2_function_types_h */

--- a/FMIL/src/Util/include/FMI3/fmi3_enums.h
+++ b/FMIL/src/Util/include/FMI3/fmi3_enums.h
@@ -1,0 +1,326 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI3_ENUMS_H_
+#define FMI3_ENUMS_H_
+
+#include <FMI3/fmi3_function_types.h>
+#include <fmilib_config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file fmi3_enums.h
+    \brief Definions the enum types used with FMI 3.0 libs
+*/
+
+/**    \addtogroup fmi3_utils
+    @{
+    \addtogroup fmi3_enums
+    @}
+*/
+/** \addtogroup fmi3_enums Enum types used with FMI 3.0 libs
+    @{
+*/
+/** \brief Naming convention for the variables in XML file*/
+typedef enum fmi3_variable_naming_convension_enu_t
+{
+        fmi3_naming_enu_flat,
+        fmi3_naming_enu_structured,
+        fmi3_naming_enu_unknown
+} fmi3_variable_naming_convension_enu_t;
+
+/** \brief Convert a #fmi3_variable_naming_convension_enu_t constant into string */
+FMILIB_EXPORT const char* fmi3_naming_convention_to_string(fmi3_variable_naming_convension_enu_t convention);
+
+/** \brief FMU 3.0 kinds. Enum types are specified as bit fields.
+     A multi-kind FMU, for example ME + CS is defined as:
+     'int fmu_kind_me_cs = fmi3_fmu_kind_me | fmi3_fmu_kind_cs'
+     The same technique can be used to check if a retrieved fmu_kind has a
+     specific kind:
+     'int has_cs = fmi3_fmu_kind_cs & my_retrieved_fmu_kind'
+ */
+typedef enum fmi3_fmu_kind_enu_t
+{
+        fmi3_fmu_kind_unknown   = 1 << 0,
+        fmi3_fmu_kind_me        = 1 << 1,
+        fmi3_fmu_kind_cs        = 1 << 2,
+        fmi3_fmu_kind_se        = 1 << 3
+} fmi3_fmu_kind_enu_t;
+
+/** \brief Convert a #fmi3_fmu_kind_enu_t constant into string  */
+FMILIB_EXPORT const char* fmi3_fmu_kind_to_string(fmi3_fmu_kind_enu_t kind);
+
+/**  \brief Variability property for variables */
+typedef enum fmi3_variability_enu_t {
+        fmi3_variability_enu_constant    = 0,
+        fmi3_variability_enu_fixed       = 1,
+        fmi3_variability_enu_tunable     = 2,
+        fmi3_variability_enu_discrete    = 3,
+        fmi3_variability_enu_continuous  = 4,
+        fmi3_variability_enu_unknown     = 5
+} fmi3_variability_enu_t;
+
+/** \brief Convert a #fmi3_variability_enu_t constant into string  */
+FMILIB_EXPORT const char* fmi3_variability_to_string(fmi3_variability_enu_t v);
+
+/**  \brief Causality property for variables */
+typedef enum fmi3_causality_enu_t {
+        fmi3_causality_enu_structural_parameter = 0,
+        fmi3_causality_enu_parameter            = 1,
+        fmi3_causality_enu_calculated_parameter = 2,
+        fmi3_causality_enu_input                = 3,
+        fmi3_causality_enu_output               = 4,
+        fmi3_causality_enu_local                = 5,
+        fmi3_causality_enu_independent          = 6,
+        fmi3_causality_enu_unknown              = 7
+} fmi3_causality_enu_t;
+
+/** \brief Convert a #fmi3_causality_enu_t constant into string */
+FMILIB_EXPORT const char* fmi3_causality_to_string(fmi3_causality_enu_t c);
+
+/** \brief Convert a #fmi3_status_t variable to string */
+FMILIB_EXPORT const char* fmi3_status_to_string(fmi3_status_t status);
+
+/**
+ * \brief Get the default variability for a given causality and if the variable is Float32/Float64.
+ * For parameter type causality, the default is 'fixed'
+ * For other causality, if Float32/64: 'continuous' and else: 'discrete'
+ * 
+ * @param c causality
+ * @param isFloat non-zero for Float32/Float64 variables
+ *
+ * @return A default variability compatible with the given causality.
+ *
+ */
+FMILIB_EXPORT fmi3_variability_enu_t fmi3_get_default_valid_variability(fmi3_causality_enu_t c, int isFloat);
+
+/**
+ * \brief Check if a given combination of variablity and causality is valid.
+ *
+ * @return 0 if not valid, non-zero otherwise
+ */
+FMILIB_EXPORT int fmi3_is_valid_variability_causality(fmi3_variability_enu_t v,
+                                                      fmi3_causality_enu_t c);
+
+/**  \brief Initial property for variables */
+typedef enum fmi3_initial_enu_t {
+        fmi3_initial_enu_exact,
+        fmi3_initial_enu_approx,
+        fmi3_initial_enu_calculated,
+        fmi3_initial_enu_unknown /* must be last*/
+} fmi3_initial_enu_t;
+
+/** \brief Convert a #fmi3_initial_enu_t constant into string  */
+FMILIB_EXPORT const char* fmi3_initial_to_string(fmi3_initial_enu_t c);
+
+/**
+    \brief Get default initial attribute value for the given variability and causality combination.
+    @return The default initial attribute or fmi3_initial_enu_unknown if combination of causality
+            and variability is not valid.
+*/
+FMILIB_EXPORT fmi3_initial_enu_t fmi3_get_default_initial(fmi3_variability_enu_t v, fmi3_causality_enu_t c);
+
+/**
+    \brief Check if the combination of variability, causality and initial is valid.
+    @return Same initial as submitted if the combination is valid. Otherwise, same as fmi3_get_default_initial.
+*/
+FMILIB_EXPORT fmi3_initial_enu_t fmi3_get_valid_initial(fmi3_variability_enu_t v, fmi3_causality_enu_t c, fmi3_initial_enu_t i);
+
+/** \brief Base types used in type definitions */
+typedef enum fmi3_base_type_enu_t
+{
+    fmi3_base_type_float64 = 1,
+    fmi3_base_type_float32,
+    fmi3_base_type_int64,
+    fmi3_base_type_int32,
+    fmi3_base_type_int16,
+    fmi3_base_type_int8,
+    fmi3_base_type_uint64,
+    fmi3_base_type_uint32,
+    fmi3_base_type_uint16,
+    fmi3_base_type_uint8,
+    fmi3_base_type_bool,
+    fmi3_base_type_binary,
+    fmi3_base_type_clock,
+    fmi3_base_type_str,
+    fmi3_base_type_enum,
+} fmi3_base_type_enu_t;
+
+/**  \brief Convert base type constant to string
+    @param bt Base type identifier.
+    @return Corresponding base type name.
+    */
+FMILIB_EXPORT const char* fmi3_base_type_to_string(fmi3_base_type_enu_t bt);
+
+/** \brief Base types used in type definitions */
+typedef enum fmi3_interval_variability_enu_t {
+    fmi3_interval_variability_unknown = 0,
+    fmi3_interval_variability_constant,
+    fmi3_interval_variability_fixed,
+    fmi3_interval_variability_tunable,
+    fmi3_interval_variability_changing,
+    fmi3_interval_variability_countdown,
+    fmi3_interval_variability_triggered
+} fmi3_interval_variability_enu_t;
+
+/** \brief List of capability flags for ModelExchange */
+#define FMI3_ME_CAPABILITIES(H) \
+    H(needsExecutionTool) \
+    H(canBeInstantiatedOnlyOncePerProcess) \
+    H(canGetAndSetFMUState) \
+    H(canSerializeFMUState) \
+    H(providesDirectionalDerivatives) \
+    H(providesAdjointDerivatives) \
+    H(providesPerElementDependencies) \
+    \
+    H(needsCompletedIntegratorStep) \
+    H(providesEvaluateDiscreteStates)
+
+/** \brief List of capability flags for CoSimulation */
+#define FMI3_CS_CAPABILITIES(H) \
+    H(needsExecutionTool) \
+    H(canBeInstantiatedOnlyOncePerProcess) \
+    H(canGetAndSetFMUState) \
+    H(canSerializeFMUState) \
+    H(providesDirectionalDerivatives) \
+    H(providesAdjointDerivatives) \
+    H(providesPerElementDependencies) \
+    \
+    H(canHandleVariableCommunicationStepSize) \
+    H(maxOutputDerivativeOrder) \
+    H(providesIntermediateUpdate) \
+    H(mightReturnEarlyFromDoStep) \
+    H(canReturnEarlyAfterIntermediateUpdate) \
+    H(hasEventMode) \
+    H(providesEvaluateDiscreteStates) \
+    H(fixedInternalStepSize) \
+    H(recommendedIntermediateInputSmoothness)
+
+
+/** \brief List of capability flags for ScheduledExecution */
+#define FMI3_SE_CAPABILITIES(H) \
+    H(needsExecutionTool) \
+    H(canBeInstantiatedOnlyOncePerProcess) \
+    H(canGetAndSetFMUState) \
+    H(canSerializeFMUState) \
+    H(providesDirectionalDerivatives) \
+    H(providesAdjointDerivatives) \
+    H(providesPerElementDependencies)
+
+#define FMI3_EXPAND_ME_CAPABILITIES_ENU(c) fmi3_me_ ## c,
+#define FMI3_EXPAND_CS_CAPABILITIES_ENU(c) fmi3_cs_ ## c,
+#define FMI3_EXPAND_SE_CAPABILITIES_ENU(c) fmi3_se_ ## c,
+
+/** \brief Capability flags for ModelExchange, CoSimulation and ScheduledExecution */
+typedef enum fmi3_capabilities_enu_t {
+    FMI3_ME_CAPABILITIES(FMI3_EXPAND_ME_CAPABILITIES_ENU)
+    FMI3_CS_CAPABILITIES(FMI3_EXPAND_CS_CAPABILITIES_ENU)
+    FMI3_SE_CAPABILITIES(FMI3_EXPAND_SE_CAPABILITIES_ENU)
+    fmi3_capabilities_num
+} fmi3_capabilities_enu_t;
+
+/** \brief Convert capability flag to a string
+    @param id Capability flag ID.
+    @return Name of the flag or Unknown if the id is out of range.
+*/
+FMILIB_EXPORT const char* fmi3_capability_to_string(fmi3_capabilities_enu_t id);
+
+/** \brief List of SI base units used in Unit defitions*/
+#define FMI3_SI_BASE_UNITS(H) \
+    H(kg) H(m) H(s) H(A) H(K) H(mol) H(cd) H(rad)
+
+/** \brief SI base units used in Unit defitions*/
+typedef enum fmi3_SI_base_units_enu_t {
+#define FMI3_EXPAND_SI_BASE_UNIT_ENU(c) fmi3_SI_base_unit_ ## c,
+    FMI3_SI_BASE_UNITS(FMI3_EXPAND_SI_BASE_UNIT_ENU)
+    fmi3_SI_base_units_Num
+} fmi3_SI_base_units_enu_t;
+
+/** \brief Convert SI base unit ID a string
+    @param id SI base unit ID.
+    @return Name of the base unit or "unknown" if the id is out of range.
+*/
+FMILIB_EXPORT const char * fmi3_SI_base_unit_to_string(fmi3_SI_base_units_enu_t id);
+
+/** \brief Convert a list of SI base unit exponents (corresponding to the IDs from  fmi3_SI_base_units_enu_t)
+    to a string of the form kg*m^2/s^2. Prints '-' if all the exponents are zero.
+    @param exp An array of SI base units exponents.
+    @param bufSize Size of the buffer to store the string.
+    @param buf Buffer to store the string
+    @return Required size of the buffer to store the string. This most likely be under [8*fmi3_SI_base_units_Num].
+    If the return value is larger or equal than bufSize than the string could not be fitted in the buffer.
+*/
+FMILIB_EXPORT size_t fmi3_SI_base_unit_exp_to_string(const int exp[fmi3_SI_base_units_Num], size_t bufSize, char buf[]);
+
+
+/** \brief Dependency factor kinds are used as part of ModelStructure definition */
+typedef enum fmi3_dependencies_kind_enu_t
+{
+    fmi3_dependencies_kind_dependent = 0,
+    fmi3_dependencies_kind_constant,
+    fmi3_dependencies_kind_fixed,
+    fmi3_dependencies_kind_tunable,
+    fmi3_dependencies_kind_discrete,
+    fmi3_dependencies_kind_num
+} fmi3_dependencies_kind_enu_t;
+
+/** \brief Test if the input argument of type fmi3_base_type_enu_t is representing bool.
+    @param enums The object of type fmi3_base_type_enu_t to check.
+    @return Returns true for bool, otherwise false.
+*/
+bool fmi3_base_type_enu_is_bool(fmi3_base_type_enu_t enums);
+
+
+/** \brief Test if the input argument of type fmi3_base_type_enu_t is representing [u]int8/32/64.
+    @param enums The object of type fmi3_base_type_enu_t to check.
+    @return Returns true for any of the signed/unsigned integer types, otherwise false.
+*/
+bool fmi3_base_type_enu_is_int(fmi3_base_type_enu_t enums);
+
+/** \brief Test if the input argument of type fmi3_base_type_enu_t* is representing float32 or float64.
+    @param enums The object of type fmi3_base_type_enu_t to check.
+    @return Returns true for float32 and float64, otherwise false.
+*/
+bool fmi3_base_type_enu_is_float(fmi3_base_type_enu_t enums);
+
+/** \brief Test if the input argument of type fmi3_base_type_enu_t* is representing an enumeration.
+    @param enums The object of type fmi3_base_type_enu_t to check.
+    @return Returns true for enums otherwise false.
+*/
+bool fmi3_base_type_enu_is_enum(fmi3_base_type_enu_t enums);
+
+/** \brief Bitness for types such as Float32/Float64 */
+typedef enum fmi3_bitness_enu_t {
+    fmi3_bitness_64 = 1,
+    fmi3_bitness_32,
+    fmi3_bitness_16,
+    fmi3_bitness_8
+} fmi3_bitness_enu_t;
+
+/**  \brief Convert dependency factor kind constant to string
+    @param fc Dependency factor kind identifier.
+    @return Corresponding factor kind as string.
+    */
+FMILIB_EXPORT const char* fmi3_dependencies_kind_to_string(fmi3_dependencies_kind_enu_t fc);
+/**
+ @}
+*/
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* End of header file FMI3_ENUMS_H_ */

--- a/FMIL/src/Util/include/FMI3/fmi3_function_types.h
+++ b/FMIL/src/Util/include/FMI3/fmi3_function_types.h
@@ -1,0 +1,548 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/**
+ * This file is used instead of fmi3FunctionsTypes.h. FMIL has no dependency
+ * (except tests) to that file, so make sure to keep the files synched (or
+ * or there will be a mismatch when trying to assign the functions loaded
+ * from the FMU to FMIL's CAPI FMU struct).
+ *
+ * This file just copies the function types to the FMIL namespace, that is,
+ * so we can use the FMIL naming conventions.
+ */
+
+#ifndef _FMI3_FUNCTION_TYPES_H_
+#define _FMI3_FUNCTION_TYPES_H_
+
+#include <string.h>
+#include <fmilib_config.h>
+
+#include "fmi3_types.h"
+/**    \file fmi3_function_types.h
+    Mapping for the standard FMI 3.0 functions into fmi3_ namespace.
+
+    \addtogroup fmi3_utils
+    @{
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Include stddef.h, in order that size_t etc. is defined */
+#include <stddef.h>
+
+/** FMI 3.0 status codes */
+typedef enum {
+    fmi3_status_ok,
+    fmi3_status_warning,
+    fmi3_status_discard,
+    fmi3_status_error,
+    fmi3_status_fatal
+} fmi3_status_t;
+
+typedef enum {
+    fmi3_interval_not_yet_known,
+    fmi3_interval_unchanged,
+    fmi3_interval_changed
+} fmi3_interval_qualifier_t;
+
+typedef enum {
+    /* fmi3_independent = 0, not needed but reserved for future use */
+    fmi3_constant  = 1,
+    fmi3_fixed     = 2,
+    fmi3_tunable   = 3,
+    fmi3_discrete  = 4,
+    fmi3_dependent = 5
+} fmi3_dependency_kind_t;
+
+typedef void  (*fmi3_log_message_callback_ft)  (fmi3_instance_environment_t instanceEnvironment,
+                                                fmi3_status_t status,
+                                                fmi3_string_t category,
+                                                fmi3_string_t message);
+
+typedef void (*fmi3_intermediate_update_callback_ft) (
+        fmi3_instance_environment_t instanceEnvironment,
+        fmi3_float64_t intermediateUpdateTime,
+        fmi3_boolean_t intermediateVariableSetRequested,
+        fmi3_boolean_t intermediateVariableGetAllowed,
+        fmi3_boolean_t intermediateStepFinished,
+        fmi3_boolean_t canReturnEarly,
+        fmi3_boolean_t* earlyReturnRequested,
+        fmi3_float64_t* earlyReturnTime);
+
+typedef void (*fmi3_clock_update_callback_ft) (
+        fmi3_instance_environment_t instanceEnvironment
+);
+typedef void (*fmi3_lock_preemption_callback_ft)   ();
+typedef void (*fmi3_unlock_preemption_callback_ft) ();
+
+/* Define fmi3 function pointer types to simplify dynamic loading */
+
+/***************************************************
+Types for Common Functions
+****************************************************/
+
+/* Inquire version numbers of header files and setting logging status */
+typedef const char* (*fmi3_get_version_ft)(void);
+
+typedef fmi3_status_t (*fmi3_set_debug_logging_ft)(fmi3_instance_t instance,
+                                                   fmi3_boolean_t loggingOn,
+                                                   size_t nCategories,
+                                                   const fmi3_string_t categories[]);
+
+/* Creation and destruction of FMU instances and setting debug status */
+typedef fmi3_instance_t (*fmi3_instantiate_model_exchange_ft)(
+    fmi3_string_t                 instanceName,
+    fmi3_string_t                 instantiationToken,
+    fmi3_string_t                 resourcePath,
+    fmi3_boolean_t                visible,
+    fmi3_boolean_t                loggingOn,
+    fmi3_instance_environment_t   instanceEnvironment,
+    fmi3_log_message_callback_ft  logMessage);
+
+typedef fmi3_instance_t (*fmi3_instantiate_co_simulation_ft)(
+    fmi3_string_t                        instanceName,
+    fmi3_string_t                        instantiationToken,
+    fmi3_string_t                        resourcePath,
+    fmi3_boolean_t                       visible,
+    fmi3_boolean_t                       loggingOn,
+    fmi3_boolean_t                       eventModeUsed,
+    fmi3_boolean_t                       earlyReturnAllowed,
+    const fmi3_value_reference_t         requiredIntermediateVariables[],
+    size_t                               nRequiredIntermediateVariables,
+    fmi3_instance_environment_t          instanceEnvironment,
+    fmi3_log_message_callback_ft         logMessage,
+    fmi3_intermediate_update_callback_ft intermediateUpdate);
+
+typedef fmi3_instance_t (*fmi3_instantiate_scheduled_execution_ft)(
+    fmi3_string_t                        instanceName,
+    fmi3_string_t                        instantiationToken,
+    fmi3_string_t                        resourcePath,
+    fmi3_boolean_t                       visible,
+    fmi3_boolean_t                       loggingOn,
+    fmi3_instance_environment_t          instanceEnvironment,
+    fmi3_log_message_callback_ft         logMessage,
+    fmi3_clock_update_callback_ft        clockUpdate,
+    fmi3_lock_preemption_callback_ft     lockPreemption,
+    fmi3_unlock_preemption_callback_ft   unlockPreemption);
+
+typedef void (*fmi3_free_instance_ft)(fmi3_instance_t instance);
+
+/* Enter and exit initialization mode, terminate and reset */
+typedef fmi3_status_t (*fmi3_enter_initialization_mode_ft) (fmi3_instance_t instance,
+                                                            fmi3_boolean_t  toleranceDefined,
+                                                            fmi3_float64_t  tolerance,
+                                                            fmi3_float64_t  startTime,
+                                                            fmi3_boolean_t  stopTimeDefined,
+                                                            fmi3_float64_t  stopTime);
+
+typedef fmi3_status_t (*fmi3_exit_initialization_mode_ft)(fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_enter_event_mode_ft)(fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_terminate_ft) (fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_reset_ft) (fmi3_instance_t instance);
+
+/* Getting and setting variable values */
+typedef fmi3_status_t (*fmi3_get_float32_ft)(fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_float32_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_float64_ft)(fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_float64_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_int8_ft)   (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_int8_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_uint8_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_uint8_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_int16_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_int16_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_uint16_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_uint16_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_int32_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_int32_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_uint32_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_uint32_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_int64_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_int64_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_uint64_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_uint64_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_boolean_ft)(fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_boolean_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_string_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3_string_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_get_binary_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             size_t sizes[],
+                                             fmi3_binary_t values[],
+                                             size_t nValues);
+
+/* Setters */
+typedef fmi3_status_t (*fmi3_set_float32_ft)(fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_float32_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_float64_ft)(fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_float64_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_int8_ft)   (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_int8_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_uint8_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_uint8_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_int16_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_int16_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_uint16_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_uint16_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_int32_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_int32_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_uint32_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_uint32_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_int64_ft)  (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_int64_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_uint64_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_uint64_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_boolean_ft)(fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_boolean_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_string_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const fmi3_string_t values[],
+                                             size_t nValues);
+
+typedef fmi3_status_t (*fmi3_set_binary_ft) (fmi3_instance_t instance,
+                                             const fmi3_value_reference_t valueReferences[],
+                                             size_t nValueReferences,
+                                             const size_t sizes[],
+                                             const fmi3_binary_t values[],
+                                             size_t nValues);
+
+/* Getting Variable Dependency Information */
+typedef fmi3_status_t (*fmi3_get_number_of_variable_dependencies_ft)(
+        fmi3_instance_t        instance,
+        fmi3_value_reference_t value_reference,
+        size_t*                n_dependencies);
+
+typedef fmi3_status_t (*fmi3_get_variable_dependencies_ft)(
+        fmi3_instance_t        instance,
+        fmi3_value_reference_t dependent,
+        size_t                 element_indices_of_dependent[],
+        fmi3_value_reference_t independents[],
+        size_t                 element_indices_of_independents[],
+        fmi3_dependency_kind_t dependency_kinds[],
+        size_t                 n_dependencies);
+
+/* Getting and setting the internal FMU state */
+typedef fmi3_status_t (*fmi3_get_fmu_state_ft)(fmi3_instance_t instance, fmi3_FMU_state_t* FMUState);
+
+typedef fmi3_status_t (*fmi3_set_fmu_state_ft)(fmi3_instance_t instance, fmi3_FMU_state_t  FMUState);
+
+typedef fmi3_status_t (*fmi3_free_fmu_state_ft)(fmi3_instance_t instance, fmi3_FMU_state_t* FMUState);
+
+typedef fmi3_status_t (*fmi3_serialized_fmu_state_size_ft)(
+        fmi3_instance_t instance,
+        fmi3_FMU_state_t FMUState,
+        size_t* size);
+
+typedef fmi3_status_t (*fmi3_serialize_fmu_state_ft)(
+        fmi3_instance_t instance,
+        fmi3_FMU_state_t FMUState,
+        fmi3_byte_t serializedState[],
+        size_t size);
+
+typedef fmi3_status_t (*fmi3_de_serialize_fmu_state_ft)(
+        fmi3_instance_t instance,
+        const fmi3_byte_t serializedState[],
+        size_t size,
+        fmi3_FMU_state_t* FMUState);
+
+/* Getting directional derivatives */
+typedef fmi3_status_t (*fmi3_get_directional_derivative_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t unknowns[],
+        size_t nUnknowns,
+        const fmi3_value_reference_t knowns[],
+        size_t nKnowns,
+        const fmi3_float64_t seed[],
+        size_t nSeed,
+        fmi3_float64_t sensitivity[],
+        size_t nSensitivity);
+
+typedef fmi3_status_t (*fmi3_get_adjoint_derivative_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t unknowns[],
+        size_t nUnknowns,
+        const fmi3_value_reference_t knowns[],
+        size_t nKnowns,
+        const fmi3_float64_t seed[],
+        size_t nSeed,
+        fmi3_float64_t sensitivity[],
+        size_t nSensitivity);
+
+/* Entering and exiting the Configuration or Reconfiguration Mode */
+typedef fmi3_status_t (*fmi3_enter_configuration_mode_ft)(fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_exit_configuration_mode_ft)(fmi3_instance_t instance);
+
+/* Clock related functions */
+typedef fmi3_status_t (*fmi3_get_clock_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_clock_t values[]);
+
+typedef fmi3_status_t (*fmi3_set_clock_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_clock_t values[]);
+
+typedef fmi3_status_t (*fmi3_get_interval_decimal_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_float64_t intervals[],
+        fmi3_interval_qualifier_t qualifiers[]);
+
+typedef fmi3_status_t (*fmi3_set_shift_decimal_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_float64_t shifts[]);
+
+typedef fmi3_status_t (*fmi3_get_shift_decimal_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_float64_t shifts[]);
+
+typedef fmi3_status_t (*fmi3_set_shift_fraction_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_uint64_t counters[],
+        const fmi3_uint64_t resolutions[]);
+
+typedef fmi3_status_t (*fmi3_get_shift_fraction_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_uint64_t counters[],
+        fmi3_uint64_t resolutions[]);
+
+typedef fmi3_status_t (*fmi3_get_interval_fraction_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        fmi3_uint64_t counters[],
+        fmi3_uint64_t resolutions[],
+        fmi3_interval_qualifier_t qualifiers[]);
+
+typedef fmi3_status_t (*fmi3_set_interval_decimal_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_float64_t intervals[]);
+
+typedef fmi3_status_t (*fmi3_set_interval_fraction_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_uint64_t counters[],
+        const fmi3_uint64_t resolutions[]);
+
+typedef fmi3_status_t (*fmi3_evaluate_discrete_states_ft)(
+        fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_update_discrete_states_ft)(
+        fmi3_instance_t instance,
+        fmi3_boolean_t *discreteStatesNeedUpdate,
+        fmi3_boolean_t *terminateSimulation,
+        fmi3_boolean_t *nominalsOfContinuousStatesChanged,
+        fmi3_boolean_t *valuesOfContinuousStatesChanged,
+        fmi3_boolean_t *nextEventTimeDefined,
+        fmi3_float64_t *nextEventTime);
+
+/***************************************************
+Types for Functions for FMI for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+typedef fmi3_status_t (*fmi3_enter_continuous_time_mode_ft)(fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_completed_integrator_step_ft) (
+        fmi3_instance_t instance,
+        fmi3_boolean_t  noSetFMUStatePriorToCurrentPoint,
+        fmi3_boolean_t* enterEventMode,
+        fmi3_boolean_t* terminateSimulation);
+
+/* Providing independent variables and re-initialization of caching */
+typedef fmi3_status_t (*fmi3_set_time_ft)(fmi3_instance_t instance, fmi3_float64_t time);
+
+typedef fmi3_status_t (*fmi3_set_continuous_states_ft)(
+        fmi3_instance_t instance,
+        const fmi3_float64_t x[],
+        size_t nx);
+
+/* Evaluation of the model equations */
+typedef fmi3_status_t (*fmi3_get_derivatives_ft)(
+        fmi3_instance_t instance,
+        fmi3_float64_t derivatives[],
+        size_t nx);
+
+typedef fmi3_status_t (*fmi3_get_event_indicators_ft)(
+        fmi3_instance_t instance,
+        const fmi3_float64_t eventIndicators[],
+        size_t nx);
+
+typedef fmi3_status_t (*fmi3_get_continuous_states_ft)(
+        fmi3_instance_t instance,
+        const fmi3_float64_t x[],
+        size_t nx);
+
+typedef fmi3_status_t (*fmi3_get_nominals_of_continuous_states_ft)(
+        fmi3_instance_t instance,
+        const fmi3_float64_t nominals[],
+        size_t nx);
+
+typedef fmi3_status_t (*fmi3_get_number_of_event_indicators_ft)(fmi3_instance_t instance, size_t* nz);
+
+typedef fmi3_status_t (*fmi3_get_number_of_continuous_states_ft)(fmi3_instance_t instance, size_t* nx);
+
+/***************************************************
+Types for Functions for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+typedef fmi3_status_t (*fmi3_enter_step_mode_ft)(fmi3_instance_t instance);
+
+typedef fmi3_status_t (*fmi3_get_output_derivatives_ft)(
+        fmi3_instance_t instance,
+        const fmi3_value_reference_t valueReferences[],
+        size_t nValueReferences,
+        const fmi3_int32_t orders[],
+        fmi3_float64_t values[],
+        size_t nValues);
+
+typedef fmi3_status_t (*fmi3_do_step_ft)(fmi3_instance_t instance,
+                                         fmi3_float64_t currentCommunicationPoint,
+                                         fmi3_float64_t communicationStepSize,
+                                         fmi3_boolean_t noSetFMUStatePriorToCurrentPoint,
+                                         fmi3_boolean_t* eventHandlingNeeded,
+                                         fmi3_boolean_t* terminate,
+                                         fmi3_boolean_t* earlyReturn,
+                                         fmi3_float64_t* lastSuccessfulTime);
+
+typedef fmi3_status_t (*fmi3_activate_model_partition_ft)(
+        fmi3_instance_t instance,
+        fmi3_value_reference_t clockReference,
+        fmi3_float64_t activationTime);
+
+/**    @}
+*/
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi3_function_types_h */

--- a/FMIL/src/Util/include/FMI3/fmi3_types.h
+++ b/FMIL/src/Util/include/FMI3/fmi3_types.h
@@ -1,0 +1,90 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI3_TYPES_H_
+#define FMI3_TYPES_H_
+/** \file fmi3_types.h
+    Transformation of the standard FMI type names into fmi3_ prefixed.
+*/
+/**
+    \addtogroup jm_utils
+    @{
+        \addtogroup fmi3_utils
+    @}
+*/
+
+/**    \addtogroup fmi3_utils Functions and types supporting FMI 3.0 processing
+    @{
+*/
+/** \name Renaming of typedefs 
+@{*/
+#define fmi3Instance            fmi3_instance_t
+#define fmi3InstanceEnvironment fmi3_instance_environment_t
+#define fmi3FMUState            fmi3_FMU_state_t
+#define fmi3ValueReference      fmi3_value_reference_t
+#define fmi3Float32             fmi3_float32_t
+#define fmi3Float64             fmi3_float64_t
+#define fmi3UInt8               fmi3_uint8_t
+#define fmi3Int8                fmi3_int8_t
+#define fmi3UInt16              fmi3_uint16_t
+#define fmi3Int16               fmi3_int16_t
+#define fmi3UInt32              fmi3_uint32_t
+#define fmi3Int32               fmi3_int32_t
+#define fmi3Int64               fmi3_int64_t
+#define fmi3UInt64              fmi3_uint64_t
+#define fmi3Boolean             fmi3_boolean_t
+#define fmi3Char                fmi3_char_t
+#define fmi3String              fmi3_string_t
+#define fmi3Byte                fmi3_byte_t
+#define fmi3Binary              fmi3_binary_t
+#define fmi3Clock               fmi3_clock_t
+
+/** @}*/
+/* Standard FMI 3.0 types */
+#ifdef fmi3PlatformTypes_h
+#undef fmi3PlatformTypes_h
+#endif
+#include <FMI3/fmi3PlatformTypes.h>
+#undef fmi3PlatformTypes_h
+
+/** FMI boolean constants.*/
+typedef enum {
+    fmi3_true  = fmi3True,
+    fmi3_false = fmi3False
+} fmi3_boolean_enu_t;
+
+#undef fmi3True
+#undef fmi3False
+
+/** FMI clock constants. */
+typedef enum {
+    fmi3_clock_active   = fmi3ClockActive,
+    fmi3_clock_inactive = fmi3ClockInactive
+} fmi3_clock_enu_t;
+
+#undef fmi3ClockActive
+#undef fmi3ClockInActive
+
+/**
+    @}
+*/
+
+#undef fmi3Instance
+#undef fmi3ValueReference
+#undef fmi3Boolean
+#undef fmi3String
+#undef fmi3UndefinedValueReference
+
+#endif /* End of header file FMI3_TYPES_H_ */

--- a/FMIL/src/Util/include/FMI3/fmi3_xml_callbacks.h
+++ b/FMIL/src/Util/include/FMI3/fmi3_xml_callbacks.h
@@ -1,0 +1,125 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI3_XML_CALLBACKS_H
+#define FMI3_XML_CALLBACKS_H
+
+#include <fmilib_config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/** \file fmi3_xml_callbacks.h Definition of ::fmi3_xml_callbacks_t and supporting functions
+    *
+    * \addtogroup fmi3_utils
+    * @{
+        \addtogroup fmi3_xml_callbacks
+    * @}
+*/
+/** \addtogroup fmi3_xml_callbacks Definition of XML callbacks struct
+* @{  */
+typedef struct fmi3_xml_callbacks_t fmi3_xml_callbacks_t;
+
+/** \name XML handling callbacks
+* @{ 
+*/
+/** \brief Handle start of an XML element within tool annotation in a SAX parser.
+*
+*   @param context as specified when setting up the callbacks,
+*   @param parentName - tool name as given by name attibute to the Tool elelent,
+*   @param parent - NULL for model level annotations; fmi3_import_variable_t * variable pointer for variable annotations. 
+*   @param elm - name of the element, 
+*   @param attr - attributes (names and values).
+*  The function should return 0 on success or error code on exit (in which case parsing will be aborted).
+*/
+typedef int (*fmi3_xml_element_start_handle_ft)(void* context, const char *toolName, void* parent, const char *elm, const char **attr);
+
+/** \brief Handle data of an XML element within tool annotation in a SAX parser.
+*
+*  @param context as specified when setting up the callbacks
+*  @param s - data string
+*  @param len - length of the data.
+*  The function should return 0 on success or error code on exit (in which case parsing will be aborted).
+*/
+typedef int (*fmi3_xml_element_data_handle_ft)(void* context, const char *s, int len);
+
+/** \brief Handle end of an XML element within tool annotation in a SAX parser.
+*
+*  @param context as specified when setting up the callbacks
+*  @param elm - name of the element.
+*  The function should return 0 on success or error code on exit (in which case parsing will be aborted).
+*/
+typedef int (*fmi3_xml_element_end_handle_ft)(void* context, const char *elm);
+
+/** \brief XML callbacks are used to process parts of XML that are not handled by the library */
+struct fmi3_xml_callbacks_t {
+    fmi3_xml_element_start_handle_ft startHandle; /** \brief Handle start of an XML element within tool annotation in a SAX parser. */
+    fmi3_xml_element_data_handle_ft  dataHandle;  /** \brief Handle data of an XML element within tool annotation in a SAX parser.  */
+    fmi3_xml_element_end_handle_ft   endHandle;   /** \brief Handle end of an XML element within tool annotation in a SAX parser. */
+    void* context;    /** \brief Context ponter is forwarded to the handle functions. */
+};
+
+/** \addtogroup fmi3_xml_callbacks Definition of XML callbacks struct
+* @{  */
+typedef struct fmi_termicon_xml_callbacks_t fmi_termicon_xml_callbacks_t;
+
+/** \name XML handling callbacks
+* @{ 
+*/
+/** \brief Handle start of an XML element within tool annotation in a SAX parser.
+*
+*   @param context as specified when setting up the callbacks,
+*   @param parentName - tool name as given by name attibute to the Tool elelent,
+*   @param parent - NULL for model level annotations; fmi3_import_variable_t * variable pointer for variable annotations. 
+*   @param elm - name of the element, 
+*   @param attr - attributes (names and values).
+*  The function should return 0 on success or error code on exit (in which case parsing will be aborted).
+*/
+typedef int (*fmi_termicon_xml_element_start_handle_ft)(void* context, const char *toolName, void* parent, const char *elm, const char **attr);
+
+/** \brief Handle data of an XML element within tool annotation in a SAX parser.
+*
+*  @param context as specified when setting up the callbacks
+*  @param s - data string
+*  @param len - length of the data.
+*  The function should return 0 on success or error code on exit (in which case parsing will be aborted).
+*/
+typedef int (*fmi_termicon_xml_element_data_handle_ft)(void* context, const char *s, int len);
+
+/** \brief Handle end of an XML element within tool annotation in a SAX parser.
+*
+*  @param context as specified when setting up the callbacks
+*  @param elm - name of the element.
+*  The function should return 0 on success or error code on exit (in which case parsing will be aborted).
+*/
+typedef int (*fmi_termicon_xml_element_end_handle_ft)(void* context, const char *elm);
+
+/** \brief XML callbacks are used to process parts of XML that are not handled by the library */
+struct fmi_termicon_xml_callbacks_t {
+    fmi_termicon_xml_element_start_handle_ft startHandle; /** \brief Handle start of an XML element within tool annotation in a SAX parser. */
+    fmi_termicon_xml_element_data_handle_ft  dataHandle;  /** \brief Handle data of an XML element within tool annotation in a SAX parser.  */
+    fmi_termicon_xml_element_end_handle_ft   endHandle;   /** \brief Handle end of an XML element within tool annotation in a SAX parser. */
+    void* context;    /** \brief Context ponter is forwarded to the handle functions. */
+};
+
+/** @} 
+*  @}
+*/
+
+#ifdef __cplusplus
+}
+#endif
+/* JM_CONTEXT_H */
+#endif

--- a/FMIL/src/XML/include/FMI/fmi_xml_terminals_and_icons.h
+++ b/FMIL/src/XML/include/FMI/fmi_xml_terminals_and_icons.h
@@ -1,0 +1,75 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi_xml_terminals_and_icons.h
+*  \brief Public interface to the FMI XML C-library.
+*/
+
+#ifndef FMI_XML_TERMINALS_AND_ICONS_H_
+#define FMI_XML_TERMINALS_AND_ICONS_H_
+
+#include <JM/jm_callbacks.h>
+#include <FMI3/fmi3_xml_callbacks.h>
+#include <FMI2/fmi2_xml_model_description.h>
+#include <FMI3/fmi3_xml_model_description.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+    \addtogroup fmi_xml
+    @{
+    \addtogroup fmi_xml_terminals_and_icons Functions for handling terminals and icons
+    @{
+*/
+
+/* Structure encapsulating terminals and icons information */
+typedef struct fmi_xml_terminals_and_icons_t fmi_xml_terminals_and_icons_t;
+/* Structure encapsulating terminal information */
+typedef struct fmi_xml_terminal_t fmi_xml_terminal_t;
+
+fmi_xml_terminals_and_icons_t* fmi_xml_allocate_terminals_and_icons(jm_callbacks* callbacks);
+void fmi_xml_free_terminals_and_icons(fmi_xml_terminals_and_icons_t* termIcon);
+
+/**
+   \brief Parse XML file
+   Repeated calls invalidate the data structures created with the previous call to fmiParseXML,
+   i.e., fmiClearModelDescrition is automatically called before reading in the new file.
+
+    @param termIcon A terminalsAndIcons object as returned by #fmi_xml_allocate_terminals_and_icons.
+    @param fileName A name (full path) of the terminalsAndIcons.xml file.
+    @param xml_callbacks Callbacks to use for processing annotations (may be NULL).
+    @return 0 if parsing was successful. Non-zero value indicates an error.
+*/
+int fmi3_xml_parse_terminals_and_icons(fmi_xml_terminals_and_icons_t* termIcon,
+                                       const char* fileName,
+                                       fmi_termicon_xml_callbacks_t* xml_callbacks);
+int fmi2_xml_terminals_and_icons_set_model_description(fmi_xml_terminals_and_icons_t* termIcon,
+                                                       fmi2_xml_model_description_t* md);
+int fmi3_xml_terminals_and_icons_set_model_description(fmi_xml_terminals_and_icons_t* termIcon,
+                                                       fmi3_xml_model_description_t* md);
+
+int fmi_xml_get_has_terminals_and_icons(fmi_xml_terminals_and_icons_t* termIcon);
+fmi_xml_terminal_t* fmi_xml_get_terminal_by_name(fmi_xml_terminals_and_icons_t* termIcon, const char* name);
+const char* fmi_xml_get_terminal_name(fmi_xml_terminal_t* term);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FMI_XML_TERMINALS_AND_ICONS_H_

--- a/FMIL/src/XML/include/FMI/fmi_xml_terminals_and_icons_scheme.h
+++ b/FMIL/src/XML/include/FMI/fmi_xml_terminals_and_icons_scheme.h
@@ -1,0 +1,115 @@
+/*
+    Copyright (C) 2024 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI_XML_TERMINALS_AND_ICONS_SCEHEME_H
+#define FMI_XML_TERMINALS_AND_ICONS_SCEHEME_H
+
+#include <FMI3/fmi3_xml_parser_scheme_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Attribute names found in terminalsAndIcons.xml */
+#define FMI_XML_ATTRLIST_TERM_ICON(EXPAND_XML_ATTRNAME) \
+    EXPAND_XML_ATTRNAME(fmiVersion) \
+    EXPAND_XML_ATTRNAME(name) \
+    EXPAND_XML_ATTRNAME(description)
+
+/* Element names found in terminalsAndIcons.xml */
+#define FMI_XML_ELMLIST_TERM_ICON(EXPAND_XML_ELMNAME) \
+    EXPAND_XML_ELMNAME(fmiTerminalsAndIcons) \
+    EXPAND_XML_ELMNAME(Terminals) \
+    EXPAND_XML_ELMNAME(Terminal) \
+    EXPAND_XML_ELMNAME(TerminalMemberVariable) \
+    EXPAND_XML_ELMNAME(TerminalStreamMemberVariable) \
+    EXPAND_XML_ELMNAME(TerminalGraphicalRepresentation)
+
+/** \brief Element that can be placed under different parents get alternative names from the info struct */
+#define FMI_XML_ELMLIST_ALT_TERM_ICON(EXPAND_XML_ELMNAME)
+
+/*
+    Define XML schema structure. Used to build the 'fmi_xml_scheme_termIcon_info_t' type (in fmi3_xml_parser.c).
+
+    @sib_idx:
+        the index in a sequence among siblings
+    @multi_elem:
+        if the parent can have multiple elements of this type
+*/
+/*      scheme_ID,                                              super_type,                   parent_ID,                                   sib_idx, multi_elem */
+#define fmi_xml_scheme_termIcon_fmiTerminalsAndIcons            {fmi_xml_elmID_termIcon_none, fmi_xml_elmID_termIcon_none,                 0,       0}
+
+#define fmi_xml_scheme_termIcon_Terminals                       {fmi_xml_elmID_termIcon_none, fmi_xml_elmID_termIcon_fmiTerminalsAndIcons, 1,       0}
+#define fmi_xml_scheme_termIcon_Terminal                        {fmi_xml_elmID_termIcon_none, fmi_xml_elmID_termIcon_Terminals,            0,       1}
+#define fmi_xml_scheme_termIcon_TerminalMemberVariable          {fmi_xml_elmID_termIcon_none, fmi_xml_elmID_termIcon_Terminal,             0,       1}
+#define fmi_xml_scheme_termIcon_TerminalStreamMemberVariable    {fmi_xml_elmID_termIcon_none, fmi_xml_elmID_termIcon_Terminal,             1,       1}
+#define fmi_xml_scheme_termIcon_TerminalGraphicalRepresentation {fmi_xml_elmID_termIcon_none, fmi_xml_elmID_termIcon_Terminal,             3,       0}
+
+// Attribute enum
+#define FMI_TERMICON_XML_ATTR_ID(attr) fmi_termIcon_attr_id_##attr,
+typedef enum fmi_xml_attr_termIcon_enu_t {
+    FMI_XML_ATTRLIST_TERM_ICON(FMI_TERMICON_XML_ATTR_ID)
+    fmi_xml_termIcon_attr_number
+} fmi_xml_attr_termIcon_enu_t;
+
+
+/* Build prototypes for all elm_handle_* functions */
+#define EXPAND_ELM_HANDLE_FMI_TERMICON(elm) extern int fmi_xml_handle_##elm(fmi3_xml_parser_context_t* context, const char* data);
+FMI_XML_ELMLIST_TERM_ICON    (EXPAND_ELM_HANDLE_FMI_TERMICON)
+FMI_XML_ELMLIST_ALT_TERM_ICON(EXPAND_ELM_HANDLE_FMI_TERMICON)
+
+
+/**
+ * Create an enum over all terminalsAndIcons XML elements. This enum can be used to index
+ * the following arrays:
+ *      - fmi_xml_scheme_termIcon_info
+ *      - fmi_termIcon_element_handle_map
+ */
+#define FMI_TERMICON_XML_ELM_ID(elm) fmi_xml_elmID_termIcon_##elm
+#define FMI_TERMICON_XML_LIST_ELM_ID(elm) ,FMI_TERMICON_XML_ELM_ID(elm)
+typedef enum fmi_xml_elm_termIcon_enu_t {
+    fmi_xml_elmID_termIcon_none = FMI_XML_ELMID_NONE
+    FMI_XML_ELMLIST_TERM_ICON(FMI_TERMICON_XML_LIST_ELM_ID)
+    ,fmi_xml_elm_termIcon_actual_number
+    FMI_XML_ELMLIST_ALT_TERM_ICON(FMI_TERMICON_XML_LIST_ELM_ID)
+    ,fmi_xml_elm_termIcon_number
+} fmi_xml_elm_termIcon_enu_t;
+
+typedef struct {
+    fmi_xml_elm_termIcon_enu_t superID;  /* ID of super type or NULL if none */
+    fmi_xml_elm_termIcon_enu_t parentID; /* expected parent ID for an element */
+    int siblingIndex;       /* index among siblings */
+    int multipleAllowed;    /* multiple elements of this kind kan come in a sequence as siblings*/
+} fmi_xml_scheme_termIcon_info_t;
+
+typedef struct fmi_xml_termIcon_element_handle_map_t fmi_xml_termIcon_element_handle_map_t;
+typedef int (*fmi3_xml_termIcon_element_handle_ft)(fmi3_xml_parser_context_t* context, const char* data);
+struct fmi_xml_termIcon_element_handle_map_t {
+    const char* elementName;
+    fmi3_xml_termIcon_element_handle_ft elementHandle;
+    fmi_xml_elm_termIcon_enu_t elemID;
+};
+
+jm_string fmi_xml_scheme_get_termIcon_attrName(fmi_xml_attr_termIcon_enu_t enu);
+fmi_xml_scheme_termIcon_info_t fmi_xml_scheme_get_termIcon_info(fmi_xml_elm_termIcon_enu_t enu);
+fmi_xml_termIcon_element_handle_map_t fmi_xml_scheme_get_termIcon_handle(fmi_xml_elm_termIcon_enu_t enu);
+size_t fmi_xml_get_termIcon_attr_enum_size();
+size_t fmi_xml_get_termIcon_elm_enum_size_actual();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMI_XML_TERMINALS_AND_ICONS_SCEHEME_H */

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_capabilities.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_capabilities.h
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI3_XML_CAPABILITIES_H
+#define FMI3_XML_CAPABILITIES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "FMI3/fmi3_xml_model_description.h"
+    /**
+        \file fmi3_xml_capabilities.h
+        Functions to retrieve capability flags.
+    */
+    /**
+    \addtogroup fmi3_xml
+    @{
+    \addtogroup fmi3_xml_capabilities Functions to retrieve capability flags.
+    The functions accept a pointer to ::fmi3_xml_capabilities_t returned by fmi3_xml_get_capabilities().
+    They return the flags as specified by the FMI 3.0 standard. Default values are returned for model-exachange FMUs.
+    @}
+    \addtogroup fmi3_xml_capabilities
+    @{
+    */
+/** \brief Retrieve  canHandleVariableCommunicationStepSize flag. */
+
+unsigned int fmi3_xml_get_capability(fmi3_xml_model_description_t* , fmi3_capabilities_enu_t id);
+
+
+/** 
+@}
+*/
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* FMI3_XML_CAPABILITIES_H */

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_cosim.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_cosim.h
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI_XML_COSIM_H
+#define FMI_XML_COSIM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "fmi3_xml_model_description.h"
+
+const char* fmi3_xml_get_entry_point(fmi3_xml_model_description_t* );
+const char* fmi3_xml_get_mime_type(fmi3_xml_model_description_t* );
+int fmi3_xml_get_manual_start(fmi3_xml_model_description_t* );
+
+size_t fmi3_xml_get_number_of_additional_models(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_additional_model_name(fmi3_xml_model_description_t* md, size_t index);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* FMI_XML_COSIM_H */

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_model_description.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_model_description.h
@@ -1,0 +1,301 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_xml_model_description.h
+*  \brief Public interface to the FMI XML C-library.
+*/
+
+#ifndef FMI3_XML_MODELDESCRIPTION_H_
+#define FMI3_XML_MODELDESCRIPTION_H_
+
+#include <stddef.h>
+#include <JM/jm_callbacks.h>
+#include <JM/jm_named_ptr.h>
+#include <FMI/fmi_xml_context.h>
+#include <FMI3/fmi3_types.h>
+#include <FMI3/fmi3_enums.h>
+#include <FMI3/fmi3_xml_callbacks.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**
+\addtogroup fmi_xml
+  @{
+    \addtogroup fmi3_xml
+  @}
+*/
+/**
+  \addtogroup fmi3_xml FMI 3.0 XML parsing library.
+   \brief The FMI 3.0 XML parsing library supports processing of model description XML files.
+   @{
+  \name Declarations of structs used in the interface.
+  \brief All the structures used in the interfaces are intended to
+   be treated as opaque objects by the client code.
+  @{  */
+
+/** \brief Model structure object */
+typedef struct fmi3_xml_model_structure_t fmi3_xml_model_structure_t;
+
+/**\name Type definitions supporting structures
+@{ */
+typedef struct fmi3_xml_float_typedef_t       fmi3_xml_float_typedef_t;
+typedef struct fmi3_xml_int_typedef_t         fmi3_xml_int_typedef_t;
+typedef struct fmi3_xml_enumeration_typedef_t fmi3_xml_enumeration_typedef_t;
+typedef struct fmi3_xml_binary_typedef_t      fmi3_xml_binary_typedef_t;
+typedef struct fmi3_xml_clock_typedef_t       fmi3_xml_clock_typedef_t;
+typedef struct fmi3_xml_variable_typedef_t    fmi3_xml_variable_typedef_t;
+
+typedef struct fmi3_xml_type_definition_list_t fmi3_xml_type_definition_list_t;
+/** @} */
+
+/**\name Scalar Variable types */
+/** @{ */
+/** General variable type is convenient to unify all the variable list operations */
+typedef struct fmi3_xml_variable_t fmi3_xml_variable_t;
+
+/** Typed variables are needed to support specific attributes */
+typedef struct fmi3_xml_float_variable_t   fmi3_xml_float_variable_t;
+typedef struct fmi3_xml_float64_variable_t fmi3_xml_float64_variable_t;
+typedef struct fmi3_xml_float32_variable_t fmi3_xml_float32_variable_t;
+typedef struct fmi3_xml_int_variable_t     fmi3_xml_int_variable_t;
+typedef struct fmi3_xml_int64_variable_t   fmi3_xml_int64_variable_t;
+typedef struct fmi3_xml_int32_variable_t   fmi3_xml_int32_variable_t;
+typedef struct fmi3_xml_int16_variable_t   fmi3_xml_int16_variable_t;
+typedef struct fmi3_xml_int8_variable_t    fmi3_xml_int8_variable_t;
+typedef struct fmi3_xml_uint64_variable_t  fmi3_xml_uint64_variable_t;
+typedef struct fmi3_xml_uint32_variable_t  fmi3_xml_uint32_variable_t;
+typedef struct fmi3_xml_uint16_variable_t  fmi3_xml_uint16_variable_t;
+typedef struct fmi3_xml_uint8_variable_t   fmi3_xml_uint8_variable_t;
+typedef struct fmi3_xml_string_variable_t  fmi3_xml_string_variable_t;
+typedef struct fmi3_xml_enum_variable_t    fmi3_xml_enum_variable_t;
+typedef struct fmi3_xml_bool_variable_t    fmi3_xml_bool_variable_t;
+typedef struct fmi3_xml_binary_variable_t  fmi3_xml_binary_variable_t;
+typedef struct fmi3_xml_clock_variable_t   fmi3_xml_clock_variable_t;
+/** @} */
+
+/** \name Structure encapsulating alias variable information
+ * @{
+ */
+typedef struct fmi3_xml_alias_variable_t fmi3_xml_alias_variable_t;
+typedef struct fmi3_xml_alias_variable_list_t fmi3_xml_alias_variable_list_t;
+/** @} */
+
+/** \name Structure encapsulating variable dimension information
+ * @{
+ */
+typedef struct fmi3_xml_dimension_t fmi3_xml_dimension_t;
+typedef struct fmi3_xml_dimension_list_t fmi3_xml_dimension_list_t;
+/** @} */
+
+/** \name Structures encapsulating unit information */
+/**@{ */
+typedef struct fmi3_xml_unit_t fmi3_xml_unit_t;
+typedef struct fmi3_xml_display_unit_t fmi3_xml_display_unit_t;
+typedef struct fmi3_xml_unit_definition_list_t fmi3_xml_unit_definition_list_t;
+/**@} */
+
+/**\name FMU capabilities flags */
+/**@{ */
+typedef struct fmi3_xml_capabilities_t fmi3_xml_capabilities_t;
+/**@} */
+/**    \addtogroup fmi3_xml_gen General information retrieval*/
+/**    \addtogroup fmi3_xml_init  Constuction, destruction and error checking */
+
+/** @} */
+
+/**    \addtogroup fmi3_xml_init
+@{ */
+/**
+   \brief Allocate the ModelDescription structure and initialize as empty model.
+   @return NULL pointer is returned if memory allocation fails.
+   @param callbacks - Standard FMI callbacks may be sent into the module. The argument is optional (pointer can be zero).
+*/
+fmi3_xml_model_description_t* fmi3_xml_allocate_model_description(jm_callbacks* callbacks);
+
+/**
+   \brief Parse XML file
+   Repeated calls invalidate the data structures created with the previous call to fmiParseXML,
+   i.e., fmiClearModelDescrition is automatically called before reading in the new file.
+
+    @param md A model description object as returned by fmi3_xml_allocate_model_description.
+    @param fileName A name (full path) of the XML file name with model definition.
+    @param xml_callbacks Callbacks to use for processing annotations (may be NULL).
+   @return 0 if parsing was successful. Non-zero value indicates an error.
+*/
+int fmi3_xml_parse_model_description(fmi3_xml_model_description_t* md,
+                                     const char* fileName,
+                                     fmi3_xml_callbacks_t* xml_callbacks);
+
+/**
+   Clears the data associated with the model description. This is useful if the same object
+   instance is used repeatedly to work with different XML files.
+    @param md A model description object as returned by fmi3_xml_allocate_model_description.
+*/
+void fmi3_xml_clear_model_description(fmi3_xml_model_description_t* md);
+
+/**Error handling:
+*  Many functions in the library return pointers to struct. An error is indicated by returning NULL/0-pointer.
+*  If error is returned than fmiGetLastError() functions can be used to retrieve the error message.
+*  If logging callbacks were specified then the same information is reported via logger.
+*  Memory for the error string is allocated and deallocated in the module.
+*  Client code should not store the pointer to the string since it can become invalid.
+*    @param md A model description object as returned by fmi3_xml_allocate_model_description.
+*    @return NULL-terminated string with an error message.
+*/
+const char* fmi3_xml_get_last_error(fmi3_xml_model_description_t* md);
+
+/**
+fmiClearLastError clears the error message .
+*/
+void fmi3_xml_clear_last_error(fmi3_xml_model_description_t* md);
+
+/**Release the memory allocated
+@param md A model description object as returned by fmi3_xml_allocate_model_description.
+*/
+void fmi3_xml_free_model_description(fmi3_xml_model_description_t* md);
+
+/** @} */
+/** \addtogroup fmi3_xml_gen
+ * \brief Functions for retrieving general model information. Memory for the strings is allocated and deallocated in the module.
+ *   All the functions take a model description object as returned by fmi3_xml_allocate_model_description() as a parameter.
+ *   The information is retrieved from the XML file.
+ * @{
+*/
+const char* fmi3_xml_get_model_name(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_model_identifier_ME(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_model_identifier_CS(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_model_identifier_SE(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_instantiation_token(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_description(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_author(fmi3_xml_model_description_t* md);
+const char* fmi3_xml_get_license(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_copyright(fmi3_xml_model_description_t* md);
+
+const char* fmi3_xml_get_model_version(fmi3_xml_model_description_t* md);
+const char* fmi3_xml_get_model_standard_version(fmi3_xml_model_description_t* md);
+const char* fmi3_xml_get_generation_tool(fmi3_xml_model_description_t* md);
+const char* fmi3_xml_get_generation_date_and_time(fmi3_xml_model_description_t* md);
+
+fmi3_variable_naming_convension_enu_t fmi3_xml_get_naming_convention(fmi3_xml_model_description_t* md);
+
+size_t fmi3_xml_get_number_of_continuous_states(fmi3_xml_model_description_t* md);
+
+size_t fmi3_xml_get_number_of_event_indicators(fmi3_xml_model_description_t* md);
+
+int fmi3_xml_get_default_experiment_has_start(fmi3_xml_model_description_t* md);
+int fmi3_xml_get_default_experiment_has_stop(fmi3_xml_model_description_t* md);
+int fmi3_xml_get_default_experiment_has_tolerance(fmi3_xml_model_description_t* md);
+int fmi3_xml_get_default_experiment_has_step_size(fmi3_xml_model_description_t* md);
+
+double fmi3_xml_get_default_experiment_start(fmi3_xml_model_description_t* md);
+double fmi3_xml_get_default_experiment_stop(fmi3_xml_model_description_t* md);
+double fmi3_xml_get_default_experiment_tolerance(fmi3_xml_model_description_t* md);
+double fmi3_xml_get_default_experiment_step_size(fmi3_xml_model_description_t* md);
+
+fmi3_fmu_kind_enu_t fmi3_xml_get_fmu_kind(fmi3_xml_model_description_t* md);
+
+int fmi3_xml_get_cs_has_fixed_internal_step_size(fmi3_xml_model_description_t* md);
+
+double fmi3_xml_get_cs_fixed_internal_step_size(fmi3_xml_model_description_t* md);
+int fmi3_xml_get_cs_recommended_intermediate_input_smoothness(fmi3_xml_model_description_t* md);
+
+void fmi3_xml_set_model_description_invalid(fmi3_xml_model_description_t* md); // Use for traceability
+
+/** \brief Get a pointer to the internal capabilities array */
+unsigned int* fmi3_xml_get_capabilities(fmi3_xml_model_description_t* md);
+
+/** \brief Get a capability flag by ID */
+unsigned int fmi3_xml_get_capability(fmi3_xml_model_description_t* , fmi3_capabilities_enu_t id);
+
+jm_vector(jm_voidp)* fmi3_xml_get_variables_original_order(fmi3_xml_model_description_t* md);
+
+jm_vector(jm_named_ptr)* fmi3_xml_get_variables_alphabetical_order(fmi3_xml_model_description_t* md);
+
+jm_vector(jm_voidp)* fmi3_xml_get_variables_vr_order(fmi3_xml_model_description_t* md);
+
+/**
+    \brief Get variable by variable name.
+    @param md - the model description
+    @param name - variable name
+    @return variable pointer.
+*/
+fmi3_xml_variable_t* fmi3_xml_get_variable_by_name(fmi3_xml_model_description_t* md, const char* name);
+
+/**
+    \brief Get variable by value reference.
+    @param md - the model description
+    @param vr - value reference
+    @return variable pointer.
+*/
+fmi3_xml_variable_t* fmi3_xml_get_variable_by_vr(fmi3_xml_model_description_t* md, fmi3_value_reference_t vr);
+
+/**
+    \brief Get description of variable or alias by variable name
+    @param md - the model description
+    @param name - variable name
+    @return description.
+*/
+const char* fmi3_xml_get_variable_description_by_name(fmi3_xml_model_description_t* md, const char* name);
+
+/**
+    \brief Get display unit of variable or alias by variable name
+    @param md - the model description
+    @param name - variable name
+    @return display unit, NULL if no display unit or variable not found.
+*/
+fmi3_xml_display_unit_t* fmi3_xml_get_variable_display_unit_by_name(fmi3_xml_model_description_t* md, const char* name);
+
+/** \brief Get the number of vendors that had annotations in the XML*/
+size_t fmi3_xml_get_vendors_num(fmi3_xml_model_description_t* md);
+
+/** \brief Get the name of the vendor with that had annotations in the XML by index */
+const char* fmi3_xml_get_vendor_name(fmi3_xml_model_description_t* md, size_t index);
+
+/** \brief Get the log categories defined in the XML */
+jm_vector(jm_string)* fmi3_xml_get_log_categories(fmi3_xml_model_description_t* md);
+
+/** \brief Get descriptions for the log categories defined in the XML */
+jm_vector(jm_string)* fmi3_xml_get_log_category_descriptions(fmi3_xml_model_description_t* md);
+
+/** \brief Get the source files for ME defined in the XML */
+jm_vector(jm_string)* fmi3_xml_get_source_files_me(fmi3_xml_model_description_t* md);
+
+/** \brief Get the source files for CS defined in the XML */
+jm_vector(jm_string)* fmi3_xml_get_source_files_cs(fmi3_xml_model_description_t* md);
+
+/** \brief Get the model structure pointer. NULL pointer means there was no information present in the XML */
+fmi3_xml_model_structure_t* fmi3_xml_get_model_structure(fmi3_xml_model_description_t* md);
+
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+
+#include "fmi3_xml_type.h"
+#include "fmi3_xml_unit.h"
+#include "fmi3_xml_variable.h"
+#include "fmi3_xml_capabilities.h"
+#include "fmi3_xml_cosim.h"
+#include "fmi3_xml_model_structure.h"
+
+#endif

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_model_description_scheme.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_model_description_scheme.h
@@ -1,0 +1,322 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+#ifndef FMI3_XML_MODEL_DESCRIPTION_SCHEME_H
+#define FMI3_XML_MODEL_DESCRIPTION_SCHEME_H
+
+#include <FMI3/fmi3_xml_parser_scheme_base.h>
+#include <FMI3/fmi3_enums.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Attribute names found in modelDescription.xml */
+#define FMI3_XML_ATTRLIST_MODEL_DESCR(EXPAND_XML_ATTRNAME) \
+    EXPAND_XML_ATTRNAME(fmiVersion) \
+    EXPAND_XML_ATTRNAME(name) \
+    EXPAND_XML_ATTRNAME(description) \
+    EXPAND_XML_ATTRNAME(factor) \
+    EXPAND_XML_ATTRNAME(offset) \
+    EXPAND_XML_ATTRNAME(inverse) \
+    FMI3_SI_BASE_UNITS(EXPAND_XML_ATTRNAME) \
+    EXPAND_XML_ATTRNAME(quantity) \
+    EXPAND_XML_ATTRNAME(unit) \
+    EXPAND_XML_ATTRNAME(displayUnit) \
+    EXPAND_XML_ATTRNAME(relativeQuantity) \
+    EXPAND_XML_ATTRNAME(unbounded) \
+    EXPAND_XML_ATTRNAME(min) \
+    EXPAND_XML_ATTRNAME(max) \
+    EXPAND_XML_ATTRNAME(nominal) \
+    EXPAND_XML_ATTRNAME(declaredType) \
+    EXPAND_XML_ATTRNAME(start) \
+    EXPAND_XML_ATTRNAME(derivative) \
+    EXPAND_XML_ATTRNAME(reinit) \
+    EXPAND_XML_ATTRNAME(startTime) \
+    EXPAND_XML_ATTRNAME(stopTime) \
+    EXPAND_XML_ATTRNAME(tolerance) \
+    EXPAND_XML_ATTRNAME(stepSize) \
+    EXPAND_XML_ATTRNAME(value) \
+    EXPAND_XML_ATTRNAME(valueReference) \
+    EXPAND_XML_ATTRNAME(variability) \
+    EXPAND_XML_ATTRNAME(causality) \
+    EXPAND_XML_ATTRNAME(initial) \
+    EXPAND_XML_ATTRNAME(previous) \
+    EXPAND_XML_ATTRNAME(clocks) \
+    EXPAND_XML_ATTRNAME(canHandleMultipleSetPerTimeInstant) \
+    EXPAND_XML_ATTRNAME(intermediateUpdate) \
+    EXPAND_XML_ATTRNAME(mimeType) \
+    EXPAND_XML_ATTRNAME(maxSize) \
+    EXPAND_XML_ATTRNAME(intervalVariability) \
+    EXPAND_XML_ATTRNAME(canBeDeactivated) \
+    EXPAND_XML_ATTRNAME(priority) \
+    EXPAND_XML_ATTRNAME(intervalDecimal) \
+    EXPAND_XML_ATTRNAME(shiftDecimal) \
+    EXPAND_XML_ATTRNAME(supportsFraction) \
+    EXPAND_XML_ATTRNAME(resolution) \
+    EXPAND_XML_ATTRNAME(intervalCounter) \
+    EXPAND_XML_ATTRNAME(shiftCounter) \
+    EXPAND_XML_ATTRNAME(dependencies) \
+    EXPAND_XML_ATTRNAME(dependenciesKind) \
+    EXPAND_XML_ATTRNAME(modelName) \
+    EXPAND_XML_ATTRNAME(modelIdentifier) \
+    EXPAND_XML_ATTRNAME(instantiationToken) \
+    EXPAND_XML_ATTRNAME(author) \
+    EXPAND_XML_ATTRNAME(copyright) \
+    EXPAND_XML_ATTRNAME(license) \
+    EXPAND_XML_ATTRNAME(version) \
+    EXPAND_XML_ATTRNAME(generationTool) \
+    EXPAND_XML_ATTRNAME(generationDateAndTime) \
+    EXPAND_XML_ATTRNAME(variableNamingConvention) \
+    EXPAND_XML_ATTRNAME(numberOfEventIndicators) \
+    EXPAND_XML_ATTRNAME(input) \
+    EXPAND_XML_ATTRNAME(needsExecutionTool) \
+    EXPAND_XML_ATTRNAME(canBeInstantiatedOnlyOncePerProcess) \
+    EXPAND_XML_ATTRNAME(canGetAndSetFMUState) \
+    EXPAND_XML_ATTRNAME(canSerializeFMUState) \
+    EXPAND_XML_ATTRNAME(providesDirectionalDerivatives) \
+    EXPAND_XML_ATTRNAME(providesDirectionalDerivative) /* Removed in FMI3. Used in error checking. */ \
+    EXPAND_XML_ATTRNAME(providesAdjointDerivatives) \
+    EXPAND_XML_ATTRNAME(providesPerElementDependencies) \
+    EXPAND_XML_ATTRNAME(providesEvaluateDiscreteStates) \
+    EXPAND_XML_ATTRNAME(needsCompletedIntegratorStep) \
+    EXPAND_XML_ATTRNAME(canHandleVariableCommunicationStepSize) \
+    EXPAND_XML_ATTRNAME(fixedInternalStepSize) \
+    EXPAND_XML_ATTRNAME(maxOutputDerivativeOrder) \
+    EXPAND_XML_ATTRNAME(recommendedIntermediateInputSmoothness) \
+    EXPAND_XML_ATTRNAME(providesIntermediateUpdate) \
+    EXPAND_XML_ATTRNAME(mightReturnEarlyFromDoStep) \
+    EXPAND_XML_ATTRNAME(canReturnEarlyAfterIntermediateUpdate) \
+    EXPAND_XML_ATTRNAME(hasEventMode)
+
+/* Element names found in modelDescription.xml */
+#define FMI3_XML_ELMLIST_MODEL_DESCR(EXPAND_XML_ELMNAME) \
+    EXPAND_XML_ELMNAME(fmiModelDescription) \
+    EXPAND_XML_ELMNAME(ModelExchange) \
+    EXPAND_XML_ELMNAME(CoSimulation) \
+    EXPAND_XML_ELMNAME(ScheduledExecution) \
+    EXPAND_XML_ELMNAME(SourceFiles) \
+    EXPAND_XML_ELMNAME(File) \
+    EXPAND_XML_ELMNAME(UnitDefinitions) \
+    EXPAND_XML_ELMNAME(Unit) \
+    EXPAND_XML_ELMNAME(BaseUnit) \
+    EXPAND_XML_ELMNAME(DisplayUnit) \
+    EXPAND_XML_ELMNAME(TypeDefinitions) \
+    EXPAND_XML_ELMNAME(SimpleType) \
+    EXPAND_XML_ELMNAME(Item) \
+    EXPAND_XML_ELMNAME(DefaultExperiment) \
+    EXPAND_XML_ELMNAME(VendorAnnotations) \
+    EXPAND_XML_ELMNAME(Tool) \
+    EXPAND_XML_ELMNAME(ModelVariables) \
+    EXPAND_XML_ELMNAME(Dimension) \
+    EXPAND_XML_ELMNAME(Start) \
+    EXPAND_XML_ELMNAME(Alias) \
+    EXPAND_XML_ELMNAME(Annotations) \
+    EXPAND_XML_ELMNAME(LogCategories) \
+    EXPAND_XML_ELMNAME(Category) \
+    EXPAND_XML_ELMNAME(Float64Type) \
+    EXPAND_XML_ELMNAME(Float32Type) \
+    EXPAND_XML_ELMNAME(Int64Type) \
+    EXPAND_XML_ELMNAME(Int32Type) \
+    EXPAND_XML_ELMNAME(Int16Type) \
+    EXPAND_XML_ELMNAME(Int8Type) \
+    EXPAND_XML_ELMNAME(UInt64Type) \
+    EXPAND_XML_ELMNAME(UInt32Type) \
+    EXPAND_XML_ELMNAME(UInt16Type) \
+    EXPAND_XML_ELMNAME(UInt8Type) \
+    EXPAND_XML_ELMNAME(BooleanType) \
+    EXPAND_XML_ELMNAME(BinaryType) \
+    EXPAND_XML_ELMNAME(ClockType) \
+    EXPAND_XML_ELMNAME(StringType) \
+    EXPAND_XML_ELMNAME(EnumerationType) \
+    EXPAND_XML_ELMNAME(ModelStructure) \
+    EXPAND_XML_ELMNAME(Output) \
+    EXPAND_XML_ELMNAME(ContinuousStateDerivative) \
+    EXPAND_XML_ELMNAME(ClockedState) \
+    EXPAND_XML_ELMNAME(InitialUnknown) \
+    EXPAND_XML_ELMNAME(EventIndicator) \
+    EXPAND_XML_ELMNAME(Float64) \
+    EXPAND_XML_ELMNAME(Float32) \
+    EXPAND_XML_ELMNAME(Int64) \
+    EXPAND_XML_ELMNAME(Int32) \
+    EXPAND_XML_ELMNAME(Int16) \
+    EXPAND_XML_ELMNAME(Int8) \
+    EXPAND_XML_ELMNAME(UInt64) \
+    EXPAND_XML_ELMNAME(UInt32) \
+    EXPAND_XML_ELMNAME(UInt16) \
+    EXPAND_XML_ELMNAME(UInt8) \
+    EXPAND_XML_ELMNAME(Boolean) \
+    EXPAND_XML_ELMNAME(Binary) \
+    EXPAND_XML_ELMNAME(Clock) \
+    EXPAND_XML_ELMNAME(String) \
+    EXPAND_XML_ELMNAME(Enumeration)
+
+/** \brief Element that can be placed under different parents get alternative names from the info struct */
+#define FMI3_XML_ELMLIST_ALT_MODEL_DESCR(EXPAND_XML_ELMNAME) \
+    EXPAND_XML_ELMNAME(BinaryVariableStart) \
+    EXPAND_XML_ELMNAME(StringVariableStart) \
+    EXPAND_XML_ELMNAME(VariableTool) \
+    EXPAND_XML_ELMNAME(SourceFilesCS) \
+    EXPAND_XML_ELMNAME(FileCS)
+
+/** \brief Abstract elements that are only used in the scheme verification */
+#define FMI3_XML_ELMLIST_ABSTRACT_MODEL_DESCR(EXPAND_XML_ELMNAME) \
+    EXPAND_XML_ELMNAME(Variable)
+
+// XXX: fmi3_xml_elmID_none & fmi3_xml_elmID_Start are defined in fmi3_xml_parser.h, got good style
+/*
+    Define XML schema structure. Used to build the 'fmi3_xml_scheme_modelDescription_info_t' type (in fmi3_xml_parser.c).
+
+    @sib_idx:
+        the index in a sequence among siblings
+    @multi_elem:
+        if the parent can have multiple elements of this type
+*/
+/*      scheme_ID,                                super_type,                 parent_ID,                           sib_idx, multi_elem */
+#define fmi3_xml_scheme_fmiModelDescription       {fmi3_xml_elmID_none,       fmi3_xml_elmID_none,                 0,       0}
+#define fmi3_xml_scheme_ModelExchange             {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  0,       0}
+#define fmi3_xml_scheme_SourceFiles               {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelExchange,        0,       0}
+#define fmi3_xml_scheme_File                      {fmi3_xml_elmID_none,       fmi3_xml_elmID_SourceFiles,          0,       1}
+#define fmi3_xml_scheme_CoSimulation              {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  1,       0}
+#define fmi3_xml_scheme_ScheduledExecution        {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  2,       0}
+#define fmi3_xml_scheme_SourceFilesCS             {fmi3_xml_elmID_none,       fmi3_xml_elmID_CoSimulation,         0,       0}
+#define fmi3_xml_scheme_FileCS                    {fmi3_xml_elmID_none,       fmi3_xml_elmID_SourceFilesCS,        0,       1}
+#define fmi3_xml_scheme_UnitDefinitions           {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  2,       0}
+#define fmi3_xml_scheme_Unit                      {fmi3_xml_elmID_none,       fmi3_xml_elmID_UnitDefinitions,      0,       1}
+#define fmi3_xml_scheme_BaseUnit                  {fmi3_xml_elmID_none,       fmi3_xml_elmID_Unit,                 0,       0}
+#define fmi3_xml_scheme_DisplayUnit               {fmi3_xml_elmID_none,       fmi3_xml_elmID_Unit,                 1,       1}
+#define fmi3_xml_scheme_TypeDefinitions           {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  3,       0}
+#define fmi3_xml_scheme_SimpleType                {fmi3_xml_elmID_none,       fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Float64Type               {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Float32Type               {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Int64Type                 {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Int32Type                 {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Int16Type                 {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Int8Type                  {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_UInt64Type                {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_UInt32Type                {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_UInt16Type                {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_UInt8Type                 {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_BooleanType               {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_BinaryType                {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_ClockType                 {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_StringType                {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_EnumerationType           {fmi3_xml_elmID_SimpleType, fmi3_xml_elmID_TypeDefinitions,      0,       1}
+#define fmi3_xml_scheme_Item                      {fmi3_xml_elmID_none,       fmi3_xml_elmID_EnumerationType,      0,       1}
+#define fmi3_xml_scheme_LogCategories             {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  4,       0}
+#define fmi3_xml_scheme_Category                  {fmi3_xml_elmID_none,       fmi3_xml_elmID_LogCategories,        0,       1}
+#define fmi3_xml_scheme_DefaultExperiment         {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  5,       0}
+#define fmi3_xml_scheme_VendorAnnotations         {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  6,       0}
+#define fmi3_xml_scheme_Tool                      {fmi3_xml_elmID_none,       fmi3_xml_elmID_VendorAnnotations,    0,       1}
+#define fmi3_xml_scheme_ModelVariables            {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  7,       0}
+
+#define fmi3_xml_scheme_ModelStructure            {fmi3_xml_elmID_none,       fmi3_xml_elmID_fmiModelDescription,  8,       0}
+#define fmi3_xml_scheme_Output                    {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelStructure,       0,       1}
+#define fmi3_xml_scheme_ContinuousStateDerivative {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelStructure,       1,       1}
+#define fmi3_xml_scheme_ClockedState              {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelStructure,       2,       1}
+#define fmi3_xml_scheme_InitialUnknown            {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelStructure,       3,       1}
+#define fmi3_xml_scheme_EventIndicator            {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelStructure,       4,       1}
+
+#define fmi3_xml_scheme_Variable                  {fmi3_xml_elmID_none,       fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Float64                   {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Float32                   {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Int64                     {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Int32                     {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Int16                     {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Int8                      {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_UInt64                    {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_UInt32                    {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_UInt16                    {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_UInt8                     {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Boolean                   {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Binary                    {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Clock                     {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_String                    {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+#define fmi3_xml_scheme_Enumeration               {fmi3_xml_elmID_Variable,   fmi3_xml_elmID_ModelVariables,       0,       1}
+
+#define fmi3_xml_scheme_Dimension                 {fmi3_xml_elmID_none,       fmi3_xml_elmID_Variable,             0,       1}
+#define fmi3_xml_scheme_BinaryVariableStart       {fmi3_xml_elmID_Start,      fmi3_xml_elmID_Binary,               1,       1}
+#define fmi3_xml_scheme_StringVariableStart       {fmi3_xml_elmID_Start,      fmi3_xml_elmID_String,               1,       1}
+#define fmi3_xml_scheme_Alias                     {fmi3_xml_elmID_none,       fmi3_xml_elmID_Variable,             2,       1}
+
+#define fmi3_xml_scheme_Annotations               {fmi3_xml_elmID_none,       fmi3_xml_elmID_Variable,             1,       0}
+#define fmi3_xml_scheme_VariableTool              {fmi3_xml_elmID_none,       fmi3_xml_elmID_Annotations,          0,       1}
+
+// Not used except for setting up the element handler framework:
+#define fmi3_xml_scheme_Start                     {fmi3_xml_elmID_none,       fmi3_xml_elmID_none,                 1,       0}
+
+// Attribute enum
+#define FMI3_XML_ATTR_ID(attr) fmi_attr_id_##attr,
+typedef enum fmi3_xml_attr_modelDescription_enu_t {
+    FMI3_XML_ATTRLIST_MODEL_DESCR(FMI3_XML_ATTR_ID)
+    fmi3_xml_modelDescription_attr_number
+} fmi3_xml_attr_modelDescription_enu_t;
+
+
+/* Build prototypes for all elm_handle_* functions */
+#define EXPAND_ELM_HANDLE_FMI3(elm) extern int fmi3_xml_handle_##elm(fmi3_xml_parser_context_t* context, const char* data);
+FMI3_XML_ELMLIST_MODEL_DESCR         (EXPAND_ELM_HANDLE_FMI3)
+FMI3_XML_ELMLIST_ALT_MODEL_DESCR     (EXPAND_ELM_HANDLE_FMI3)
+FMI3_XML_ELMLIST_ABSTRACT_MODEL_DESCR(EXPAND_ELM_HANDLE_FMI3)
+
+
+/**
+ * Create an enum over all modelDescription XML elements. This enum can be used to index
+ * the following arrays:
+ *      - fmi3_xml_scheme_modelDescription_info
+ *      - fmi3_modelDescription_element_handle_map
+ */
+#define FMI3_XML_ELM_ID(elm) fmi3_xml_elmID_##elm
+#define FMI3_XML_LIST_ELM_ID(elm) ,FMI3_XML_ELM_ID(elm)
+#define FMI_XML_ELMID_NONE (-1)
+typedef enum fmi3_xml_elm_modelDescription_enu_t {
+    fmi3_xml_elmID_none = FMI_XML_ELMID_NONE
+    FMI3_XML_ELMLIST_MODEL_DESCR(FMI3_XML_LIST_ELM_ID)
+    ,fmi3_xml_elm_actual_number
+    FMI3_XML_ELMLIST_ALT_MODEL_DESCR     (FMI3_XML_LIST_ELM_ID)
+    FMI3_XML_ELMLIST_ABSTRACT_MODEL_DESCR(FMI3_XML_LIST_ELM_ID)
+    ,fmi3_xml_elm_number
+} fmi3_xml_elm_modelDescription_enu_t;
+
+/** Keeps information about the allowed parent element ID, index among siblings in a sequence and if
+    multiple elements of this type are allowed in a sequence.
+*/
+typedef struct {
+    fmi3_xml_elm_modelDescription_enu_t superID;  /* ID of super type or NULL if none */
+    fmi3_xml_elm_modelDescription_enu_t parentID; /* expected parent ID for an element */
+    int siblingIndex;       /* index among siblings */
+    int multipleAllowed;    /* multiple elements of this kind kan come in a sequence as siblings*/
+} fmi3_xml_scheme_modelDescription_info_t;
+
+typedef int (*fmi3_xml_modelDescription_element_handle_ft)(fmi3_xml_parser_context_t* context, const char* data);
+
+typedef struct fmi3_xml_modelDescription_element_handle_map_t fmi3_xml_modelDescription_element_handle_map_t;
+struct fmi3_xml_modelDescription_element_handle_map_t {
+    const char* elementName;
+    fmi3_xml_modelDescription_element_handle_ft elementHandle;
+    fmi3_xml_elm_modelDescription_enu_t elemID;
+};
+
+jm_string fmi3_xml_scheme_get_modelDescription_attrName(fmi3_xml_attr_modelDescription_enu_t enu);
+fmi3_xml_scheme_modelDescription_info_t fmi3_xml_scheme_get_modelDescription_info(fmi3_xml_elm_modelDescription_enu_t enu);
+fmi3_xml_modelDescription_element_handle_map_t fmi3_xml_scheme_get_modelDescription_handle(fmi3_xml_elm_modelDescription_enu_t enu);
+size_t fmi3_xml_get_modelDescription_attr_enum_size();
+size_t fmi3_xml_get_modelDescription_elm_enum_size_actual();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMI3_XML_MODEL_DESCRIPTION_SCHEME_H */

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_model_structure.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_model_structure.h
@@ -1,0 +1,131 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_xml_model_structure.h
+*  \brief Public interface to the FMI XML C-library. Handling of ModelStructure.
+*/
+
+#ifndef FMI3_XML_MODELSTRUCTURE_H_
+#define FMI3_XML_MODELSTRUCTURE_H_
+
+#include "fmi3_xml_model_description.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+fmi3_xml_model_structure_t* fmi3_xml_allocate_model_structure(jm_callbacks* cb);
+
+void fmi3_xml_free_model_structure(fmi3_xml_model_structure_t* ms);
+
+/** \brief Get the list of all the output variables in the model.
+* @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
+* @return a variable list with all the output variables in the model.
+*/
+jm_vector(jm_voidp)* fmi3_xml_get_outputs(fmi3_xml_model_structure_t* ms);
+
+/** \brief Get the list of all the continuous state derivative variables in the model.
+* @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
+* @return a variable list with all the continuous state derivatives in the model.
+*/
+jm_vector(jm_voidp)* fmi3_xml_get_continuous_state_derivatives(fmi3_xml_model_structure_t* ms);
+
+/** \brief Get the list of all the clocked states in the model.
+* @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
+* @return a variable list with all the clocked states in the model.
+*/
+jm_vector(jm_voidp)* fmi3_xml_get_clocked_states(fmi3_xml_model_structure_t* ms);
+
+/** \brief Get the list of all the initial unknown variables in the model.
+* @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
+* @return a variable list with all the initial unknowns in the model.
+*/
+jm_vector(jm_voidp)* fmi3_xml_get_initial_unknowns(fmi3_xml_model_structure_t* ms);
+
+/** \brief Get the list of all the event indicator variables in the model.
+* @param ms A model structure pointer (returned by fmi3_xml_get_model_structure)
+* @return a variable list with all the event indicator in the model.
+*/
+jm_vector(jm_voidp)* fmi3_xml_get_event_indicators(fmi3_xml_model_structure_t* ms);
+
+/** \brief Get dependency information for an Output.
+ * @param ms               - A model structure pointer (returned by fmi3_xml_get_model_structure)
+ * @param variable         - A model variable, e.g., from fmi3_xml_get_outputs() vector.
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not an Output), invalid inputs or unexpected failures
+ */
+int fmi3_xml_get_output_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for a ContinuousStateDerivative.
+ * @param ms               - A model structure pointer (returned by fmi3_xml_get_model_structure)
+ * @param variable         - A model variable, e.g., from fmi3_xml_get_continuous_state_derivatives() vector.
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not a ContinuousStateDerivative), invalid inputs or unexpected failures
+ */
+int fmi3_xml_get_continuous_state_derivative_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for a ClockedState.
+ * @param ms               - A model structure pointer (returned by fmi3_xml_get_model_structure)
+ * @param variable         - A model variable, e.g., from fmi3_xml_get_clocked_states() vector.
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not a ClockedState), invalid inputs or unexpected failures
+ */
+int fmi3_xml_get_clocked_state_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for an InitialUnknown.
+ * @param ms               - A model structure pointer (returned by fmi3_xml_get_model_structure)
+ * @param variable         - A model variable, e.g., from fmi3_xml_get_initial_unknowns() vector.
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not an InitialUnknown), invalid inputs or unexpected failures
+ */
+int fmi3_xml_get_initial_unknown_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+/** \brief Get dependency information for an EventIndicator.
+ * @param ms               - A model structure pointer (returned by fmi3_xml_get_model_structure)
+ * @param variable         - A model variable, e.g., from fmi3_xml_get_event_indicators() vector.
+ * @param numDependencies  - outputs number of dependencies; 0 for no dependencies and depends on all, check 'dependsOnAll' output
+ * @param dependsOnAll     - outputs 1 if a variable depends on all variables, else 0. Only relevant if numDependencies == 0
+ * @param dependencies     - outputs a pointer to the dependencies (valueReferences), NULL if numDependencies == 0
+ * @param dependenciesKind - outputs a pointer to the dependencieskind data. The values can be converted to ::fmi3_dependencies_kind_enu_t 
+ *                           NULL if numDependencies == 0
+ * @return                 - non-zero if variable cannot be found (e.g., not an EventIndicator), invalid inputs or unexpected failures
+ */
+int fmi3_xml_get_event_indicator_dependencies(fmi3_xml_model_structure_t* ms, fmi3_xml_variable_t* variable,
+        size_t* numDependencies, int* dependsOnAll, size_t** dependencies, char** dependenciesKind);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_parser_scheme.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_parser_scheme.h
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2024 Modelon AB
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/*
+XML scheme interaction via unified types and APIs.
+*/
+
+#ifndef FMI3_XML_XMLPARSER_SCHEME_H
+#define FMI3_XML_XMLPARSER_SCHEME_H
+
+#include <FMI/fmi_xml_terminals_and_icons_scheme.h>
+#include <FMI3/fmi3_xml_model_description_scheme.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Flag for current XML file being handled. */
+typedef enum fmi3_xml_type_t {
+    fmi3_xml_type_modelDescription,
+    fmi3_xml_type_terminalAndIcons
+} fmi3_xml_type_t;
+
+typedef union fmi3_xml_attr_t {
+    int any; // when used in generic parser/handling context
+    fmi3_xml_attr_modelDescription_enu_t modelDescription;
+    fmi_xml_attr_termIcon_enu_t termIcon;
+} fmi3_xml_attr_t;
+
+// Shortcuts for defining fmi3_xml_attr_t for a given enum value
+#define FMI3_ATTR_ANY(enu)     (fmi3_xml_attr_t){.any = enu}
+#define FMI3_ATTR(enu)         (fmi3_xml_attr_t){.modelDescription = enu}
+#define FMI_ATTR_TERMICON(enu) (fmi3_xml_attr_t){.termIcon = enu}
+
+typedef union fmi3_xml_elm_t {
+    int any; // when used in generic parser/handling context
+    fmi3_xml_elm_modelDescription_enu_t modelDescription;
+    fmi_xml_elm_termIcon_enu_t termIcon;
+} fmi3_xml_elm_t;
+
+// Shortcuts for defining fmi3_xml_elm_t for a given enum value
+#define FMI3_ELM_ANY(enu)     (fmi3_xml_elm_t){.any = enu}
+#define FMI3_ELM(enu)         (fmi3_xml_elm_t){.modelDescription = enu}
+#define FMI_ELM_TERMICON(enu) (fmi3_xml_elm_t){.termIcon = enu}
+
+/** Keeps information about the allowed parent element ID, index among siblings in a sequence and if
+    multiple elements of this type are allowed in a sequence.
+*/
+typedef struct {
+    fmi3_xml_elm_t superID;  /* ID of super type or NULL if none */
+    fmi3_xml_elm_t parentID; /* expected parent ID for an element */
+    int siblingIndex;       /* index among siblings */
+    int multipleAllowed;    /* multiple elements of this kind kan come in a sequence as siblings*/
+} fmi3_xml_scheme_info_t;
+
+typedef struct fmi3_xml_element_handle_map_t fmi3_xml_element_handle_map_t;
+typedef int (*fmi3_xml_element_handle_ft)(fmi3_xml_parser_context_t* context, const char* data);
+struct fmi3_xml_element_handle_map_t {
+    const char* elementName;
+    fmi3_xml_element_handle_ft elementHandle;
+    fmi3_xml_elm_t elemID;
+};
+
+jm_string fmi3_xml_get_xml_attr_name(fmi3_xml_parser_context_t* context, const fmi3_xml_attr_t enu);
+fmi3_xml_scheme_info_t fmi3_xml_get_scheme_info(fmi3_xml_parser_context_t* context, fmi3_xml_elm_t enu);
+fmi3_xml_element_handle_map_t fmi3_xml_get_element_handle(fmi3_xml_parser_context_t* context, fmi3_xml_elm_t enu);
+
+size_t fmi3_xml_get_attr_enum_size(fmi3_xml_parser_context_t* context);
+size_t fmi3_xml_get_elm_enum_size_actual(fmi3_xml_parser_context_t* context);
+
+int fmi3_xml_is_valid_parent(fmi3_xml_parser_context_t* context, fmi3_xml_elm_t child_id, fmi3_xml_elm_t parent_id);
+int fmi3_xml_get_super_type_rec(fmi3_xml_parser_context_t* context, fmi3_xml_elm_t id);
+int fmi3_xml_are_same_type(fmi3_xml_parser_context_t* context, fmi3_xml_elm_t id1, fmi3_xml_elm_t id2);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMI3_XML_XMLPARSER_SCHEME_H */

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_parser_scheme_base.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_parser_scheme_base.h
@@ -1,0 +1,31 @@
+/*
+    Copyright (C) 2024 Modelon AB
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/*
+Common base functionality for defining a parser scheme, e.g., modelDescription, terminalsAndIcons
+*/
+
+#ifndef FMI3_XML_XMLPARSER_SCHEME_BASE_H
+#define FMI3_XML_XMLPARSER_SCHEME_BASE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FMI_XML_ELMID_NONE (-1)
+typedef struct fmi3_xml_parser_context_t fmi3_xml_parser_context_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMI3_XML_XMLPARSER_SCHEME_BASE_H */

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_type.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_type.h
@@ -1,0 +1,127 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_xml_type.h
+*  \brief Public interface to the FMI XML C-library: variable types handling.
+*/
+
+#ifndef FMI3_XML_TYPE_H_
+#define FMI3_XML_TYPE_H_
+
+#include "FMI3/fmi3_xml_model_description.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /**
+    \addtogroup fmi3_xml
+    @{
+    \addtogroup fmi3_xml_types Support for processing variable types
+    @}
+    \addtogroup fmi3_xml_types Support for processing variable types
+    @{
+    */
+
+fmi3_xml_type_definition_list_t* fmi3_xml_get_type_definitions(fmi3_xml_model_description_t* md);
+
+/* Convert base type constant to string */
+
+unsigned int fmi3_xml_get_type_definition_list_size(fmi3_xml_type_definition_list_t* td);
+
+fmi3_xml_variable_typedef_t* fmi3_xml_get_typedef(fmi3_xml_type_definition_list_t* td, unsigned int  index);
+
+const char* fmi3_xml_get_type_name(fmi3_xml_variable_typedef_t*);
+
+/* Note that NULL pointer is returned if the attribute is not present in the XML.*/
+const char* fmi3_xml_get_type_description(fmi3_xml_variable_typedef_t*);
+
+fmi3_base_type_enu_t fmi3_xml_get_base_type(fmi3_xml_variable_typedef_t*);
+
+/* Boolean and String has no extra attributes -> not needed*/
+
+fmi3_xml_float_typedef_t* fmi3_xml_get_type_as_float(fmi3_xml_variable_typedef_t* t);
+fmi3_xml_int_typedef_t* fmi3_xml_get_type_as_int(fmi3_xml_variable_typedef_t*);
+fmi3_xml_enumeration_typedef_t* fmi3_xml_get_type_as_enum(fmi3_xml_variable_typedef_t*);
+fmi3_xml_binary_typedef_t* fmi3_xml_get_type_as_binary(fmi3_xml_variable_typedef_t*);
+fmi3_xml_clock_typedef_t* fmi3_xml_get_type_as_clock(fmi3_xml_variable_typedef_t*);
+
+/* Note that NULL-pointer is always returned for strings and booleans */
+const char* fmi3_xml_get_type_quantity(fmi3_xml_variable_typedef_t*);
+
+int fmi3_xml_get_float64_type_is_relative_quantity(fmi3_xml_float_typedef_t*);
+int fmi3_xml_get_float64_type_is_unbounded(fmi3_xml_float_typedef_t*);
+int fmi3_xml_get_float32_type_is_relative_quantity(fmi3_xml_float_typedef_t*);
+int fmi3_xml_get_float32_type_is_unbounded(fmi3_xml_float_typedef_t*);
+fmi3_float64_t fmi3_xml_get_float64_type_min(fmi3_xml_float_typedef_t*);
+fmi3_float64_t fmi3_xml_get_float64_type_max(fmi3_xml_float_typedef_t*);
+fmi3_float64_t fmi3_xml_get_float64_type_nominal(fmi3_xml_float_typedef_t*);
+fmi3_xml_unit_t* fmi3_xml_get_float64_type_unit(fmi3_xml_float_typedef_t*);
+fmi3_xml_display_unit_t* fmi3_xml_get_float64_type_display_unit(fmi3_xml_float_typedef_t*);
+fmi3_float32_t fmi3_xml_get_float32_type_min(fmi3_xml_float_typedef_t*);
+fmi3_float32_t fmi3_xml_get_float32_type_max(fmi3_xml_float_typedef_t*);
+fmi3_float32_t fmi3_xml_get_float32_type_nominal(fmi3_xml_float_typedef_t*);
+fmi3_xml_unit_t* fmi3_xml_get_float32_type_unit(fmi3_xml_float_typedef_t*);
+fmi3_xml_display_unit_t* fmi3_xml_get_float32_type_display_unit(fmi3_xml_float_typedef_t*);
+fmi3_int64_t fmi3_xml_get_int64_type_min(fmi3_xml_int_typedef_t*);
+fmi3_int64_t fmi3_xml_get_int64_type_max(fmi3_xml_int_typedef_t*);
+fmi3_int32_t fmi3_xml_get_int32_type_min(fmi3_xml_int_typedef_t*);
+fmi3_int32_t fmi3_xml_get_int32_type_max(fmi3_xml_int_typedef_t*);
+fmi3_int16_t fmi3_xml_get_int16_type_min(fmi3_xml_int_typedef_t*);
+fmi3_int16_t fmi3_xml_get_int16_type_max(fmi3_xml_int_typedef_t*);
+fmi3_int8_t fmi3_xml_get_int8_type_min(fmi3_xml_int_typedef_t*);
+fmi3_int8_t fmi3_xml_get_int8_type_max(fmi3_xml_int_typedef_t*);
+fmi3_uint64_t fmi3_xml_get_uint64_type_min(fmi3_xml_int_typedef_t*);
+fmi3_uint64_t fmi3_xml_get_uint64_type_max(fmi3_xml_int_typedef_t*);
+fmi3_uint32_t fmi3_xml_get_uint32_type_min(fmi3_xml_int_typedef_t*);
+fmi3_uint32_t fmi3_xml_get_uint32_type_max(fmi3_xml_int_typedef_t*);
+fmi3_uint16_t fmi3_xml_get_uint16_type_min(fmi3_xml_int_typedef_t*);
+fmi3_uint16_t fmi3_xml_get_uint16_type_max(fmi3_xml_int_typedef_t*);
+fmi3_uint8_t fmi3_xml_get_uint8_type_min(fmi3_xml_int_typedef_t*);
+fmi3_uint8_t fmi3_xml_get_uint8_type_max(fmi3_xml_int_typedef_t*);
+
+int fmi3_xml_get_enum_type_min(fmi3_xml_enumeration_typedef_t*);
+int fmi3_xml_get_enum_type_max(fmi3_xml_enumeration_typedef_t*);
+unsigned int  fmi3_xml_get_enum_type_size(fmi3_xml_enumeration_typedef_t*);
+const char* fmi3_xml_get_enum_type_item_name(fmi3_xml_enumeration_typedef_t*, unsigned int  item);
+int fmi3_xml_get_enum_type_item_value(fmi3_xml_enumeration_typedef_t*, unsigned int  item);
+const char* fmi3_xml_get_enum_type_item_description(fmi3_xml_enumeration_typedef_t*, unsigned int  item);
+const char* fmi3_xml_get_enum_type_value_name(fmi3_xml_enumeration_typedef_t* t, int value);
+
+fmi3_string_t fmi3_xml_get_binary_type_mime_type(fmi3_xml_binary_typedef_t* t);
+fmi3_boolean_t fmi3_xml_get_binary_type_has_max_size(fmi3_xml_binary_typedef_t* t);
+size_t fmi3_xml_get_binary_type_max_size(fmi3_xml_binary_typedef_t* t);
+
+fmi3_boolean_t fmi3_xml_get_clock_type_can_be_deactivated(fmi3_xml_clock_typedef_t* t);
+fmi3_boolean_t fmi3_xml_get_clock_type_has_priority(fmi3_xml_clock_typedef_t* t);
+fmi3_uint32_t fmi3_xml_get_clock_type_priority(fmi3_xml_clock_typedef_t* t);
+fmi3_interval_variability_enu_t fmi3_xml_get_clock_type_interval_variability(fmi3_xml_clock_typedef_t* t);
+fmi3_boolean_t fmi3_xml_get_clock_type_has_interval_decimal(fmi3_xml_clock_typedef_t* t);
+fmi3_float64_t fmi3_xml_get_clock_type_interval_decimal(fmi3_xml_clock_typedef_t* t);
+fmi3_float64_t fmi3_xml_get_clock_type_shift_decimal(fmi3_xml_clock_typedef_t* t);
+fmi3_boolean_t fmi3_xml_get_clock_type_supports_fraction(fmi3_xml_clock_typedef_t* t);
+fmi3_boolean_t fmi3_xml_get_clock_type_has_resolution(fmi3_xml_clock_typedef_t* t);
+fmi3_uint64_t fmi3_xml_get_clock_type_resolution(fmi3_xml_clock_typedef_t* t);
+fmi3_boolean_t fmi3_xml_get_clock_type_has_interval_counter(fmi3_xml_clock_typedef_t* t);
+fmi3_uint64_t fmi3_xml_get_clock_type_interval_counter(fmi3_xml_clock_typedef_t* t);
+fmi3_uint64_t fmi3_xml_get_clock_type_shift_counter(fmi3_xml_clock_typedef_t* t);
+
+/*
+*  @}
+*/
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_unit.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_unit.h
@@ -1,0 +1,90 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_xml_unit.h
+*  \brief Public interface to the FMI XML C-library. Handling of variable units.
+*/
+
+#ifndef FMI3_XML_UNIT_H_
+#define FMI3_XML_UNIT_H_
+
+#include "fmi3_xml_model_description.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /**
+    \addtogroup fmi3_xml
+    @{
+    \addtogroup fmi3_xml_units Functions for handling unit definitions
+    @}
+    \addtogroup fmi3_xml_units Functions for handling unit definitions
+    @{
+    */
+
+/** \brief Get a list of all the unit definitions */
+fmi3_xml_unit_definition_list_t* fmi3_xml_get_unit_definition_list(fmi3_xml_model_description_t* md);
+size_t fmi3_xml_get_unit_definition_list_size(fmi3_xml_unit_definition_list_t* ud);
+fmi3_xml_unit_t* fmi3_xml_get_unit(fmi3_xml_unit_definition_list_t* ud, size_t index);
+
+const char* fmi3_xml_get_unit_name(fmi3_xml_unit_t* u);
+unsigned int fmi3_xml_get_unit_display_unit_number(fmi3_xml_unit_t* u);
+fmi3_xml_display_unit_t* fmi3_xml_get_unit_display_unit(fmi3_xml_unit_t* u, size_t index);
+
+/**
+    \brief Get fmi3_SI_base_units_Num SI base units exponents associated with the unit.
+*/
+const int* fmi3_xml_get_SI_unit_exponents(fmi3_xml_unit_t* u);
+
+/**
+    \brief Get factor to the corresponding SI base units.
+*/
+double fmi3_xml_get_SI_unit_factor(fmi3_xml_unit_t* u);
+
+/**
+    \brief Get offset to the corresponding SI base units.
+*/
+double fmi3_xml_get_SI_unit_offset(fmi3_xml_unit_t* u);
+
+/**
+    \brief Convert a value with respect to the unit to the
+    value with respect to the SI base unit.
+*/
+double fmi3_xml_convert_to_SI_base_unit(double uv, fmi3_xml_unit_t* u);
+
+/**
+    \brief Convert a value with respect to the SI base unit to the
+    value with respect to the unit.
+*/
+double fmi3_xml_convert_from_SI_base_unit(double SIv, fmi3_xml_unit_t* u);
+
+fmi3_xml_unit_t* fmi3_xml_get_base_unit(fmi3_xml_display_unit_t* du);
+const char* fmi3_xml_get_display_unit_name(fmi3_xml_display_unit_t* du);
+double fmi3_xml_get_display_unit_factor(fmi3_xml_display_unit_t* du);
+double fmi3_xml_get_display_unit_offset(fmi3_xml_display_unit_t* du);
+unsigned int fmi3_xml_get_display_unit_inverse(fmi3_xml_display_unit_t* du);
+
+fmi3_float64_t fmi3_xml_float64_convert_to_display_unit  (fmi3_float64_t value, fmi3_xml_display_unit_t* du, int isRelativeQuantity);
+fmi3_float64_t fmi3_xml_float64_convert_from_display_unit(fmi3_float64_t value, fmi3_xml_display_unit_t* du, int isRelativeQuantity);
+fmi3_float32_t fmi3_xml_float32_convert_to_display_unit  (fmi3_float32_t value, fmi3_xml_display_unit_t* du, int isRelativeQuantity);
+fmi3_float32_t fmi3_xml_float32_convert_from_display_unit(fmi3_float32_t value, fmi3_xml_display_unit_t* du, int isRelativeQuantity);
+/**
+@}
+*/
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/XML/include/FMI3/fmi3_xml_variable.h
+++ b/FMIL/src/XML/include/FMI3/fmi3_xml_variable.h
@@ -1,0 +1,215 @@
+/*
+    Copyright (C) 2023 Modelon AB
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the BSD style license.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    FMILIB_License.txt file for more details.
+
+    You should have received a copy of the FMILIB_License.txt file
+    along with this program. If not, contact Modelon AB <http://www.modelon.com>.
+*/
+
+/** \file fmi3_xml_variable.h
+*  \brief Public interface to the FMI XML C-library. Handling of model variables.
+*/
+
+#ifndef FMI3_XML_VARIABLE_H_
+#define FMI3_XML_VARIABLE_H_
+
+#include "fmi3_xml_model_description.h"
+#include "fmi3_xml_type.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+        /**
+    \addtogroup fmi3_xml
+    @{
+    \addtogroup fmi3_xml_variables Functions for handling variable definitions
+    @}
+    \addtogroup fmi3_xml_variables Functions for handling variable definitions
+    @{
+    */
+const char* fmi3_xml_get_variable_name(fmi3_xml_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_variable_has_description(fmi3_xml_variable_t* v);
+const char* fmi3_xml_get_variable_description(fmi3_xml_variable_t* v);
+
+size_t fmi3_xml_get_variable_original_order(fmi3_xml_variable_t* v);
+
+fmi3_value_reference_t fmi3_xml_get_variable_vr(fmi3_xml_variable_t* v);
+
+/*
+    For scalar variable gives the type definition is present
+*/
+fmi3_xml_variable_typedef_t* fmi3_xml_get_variable_declared_type(fmi3_xml_variable_t* v);
+fmi3_base_type_enu_t fmi3_xml_get_variable_base_type(fmi3_xml_variable_t* v);
+
+fmi3_xml_alias_variable_list_t* fmi3_xml_get_variable_aliases(fmi3_xml_variable_t* v);
+size_t fmi3_xml_get_alias_variables_number(fmi3_xml_alias_variable_list_t* aliases);
+fmi3_xml_alias_variable_t* fmi3_xml_get_alias(fmi3_xml_alias_variable_list_t* aliases, size_t index);
+const char* fmi3_xml_get_alias_variable_name(fmi3_xml_alias_variable_t* alias);
+fmi3_boolean_t fmi3_xml_get_alias_variable_has_description(fmi3_xml_alias_variable_t* alias);
+const char* fmi3_xml_get_alias_variable_description(fmi3_xml_alias_variable_t* alias);
+fmi3_xml_display_unit_t* fmi3_xml_get_alias_variable_display_unit(fmi3_xml_alias_variable_t* alias);
+fmi3_xml_alias_variable_t* fmi3_xml_get_alias_variable_by_name(fmi3_xml_variable_t* v, const char* name);
+
+int fmi3_xml_variable_is_array(fmi3_xml_variable_t* v);
+
+int fmi3_xml_get_variable_has_start(fmi3_xml_variable_t*);
+
+fmi3_variability_enu_t fmi3_xml_get_variable_variability(fmi3_xml_variable_t*);
+fmi3_causality_enu_t fmi3_xml_get_variable_causality(fmi3_xml_variable_t*);
+fmi3_initial_enu_t fmi3_xml_get_variable_initial(fmi3_xml_variable_t*);
+
+fmi3_xml_variable_t* fmi3_xml_get_variable_previous(fmi3_xml_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_variable_can_handle_multiple_set_per_time_instant(fmi3_xml_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_variable_intermediate_update(fmi3_xml_variable_t* v);
+fmi3_boolean_t fmi3_xml_variable_is_clocked(fmi3_xml_variable_t* v);
+jm_status_enu_t fmi3_xml_get_variable_clocks(fmi3_xml_model_description_t* md, fmi3_xml_variable_t* v, jm_vector(jm_voidp)* list);
+fmi3_boolean_t fmi3_xml_get_variable_is_clocked_by(fmi3_xml_variable_t* var, fmi3_xml_clock_variable_t* clock);
+
+fmi3_xml_float64_variable_t* fmi3_xml_get_variable_as_float64(fmi3_xml_variable_t*);
+fmi3_xml_float64_variable_t* fmi3_xml_get_float64_variable_derivative_of (fmi3_xml_float64_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_float64_variable_reinit (fmi3_xml_float64_variable_t* v);
+fmi3_xml_unit_t* fmi3_xml_get_float64_variable_unit (fmi3_xml_float64_variable_t* v);
+fmi3_xml_display_unit_t* fmi3_xml_get_float64_variable_display_unit (fmi3_xml_float64_variable_t* v);
+fmi3_float64_t fmi3_xml_get_float64_variable_start (fmi3_xml_float64_variable_t* v);
+fmi3_float64_t* fmi3_xml_get_float64_variable_start_array(fmi3_xml_float64_variable_t* v);
+fmi3_float64_t fmi3_xml_get_float64_variable_min (fmi3_xml_float64_variable_t* v);
+fmi3_float64_t fmi3_xml_get_float64_variable_max (fmi3_xml_float64_variable_t* v);
+fmi3_float64_t fmi3_xml_get_float64_variable_nominal (fmi3_xml_float64_variable_t* v);
+fmi3_string_t fmi3_xml_get_float64_variable_quantity (fmi3_xml_float64_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_float64_variable_unbounded (fmi3_xml_float64_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_float64_variable_relative_quantity (fmi3_xml_float64_variable_t* v);
+
+fmi3_xml_float32_variable_t* fmi3_xml_get_variable_as_float32(fmi3_xml_variable_t*);
+fmi3_xml_float32_variable_t* fmi3_xml_get_float32_variable_derivative_of (fmi3_xml_float32_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_float32_variable_reinit (fmi3_xml_float32_variable_t* v);
+fmi3_xml_unit_t* fmi3_xml_get_float32_variable_unit (fmi3_xml_float32_variable_t* v);
+fmi3_xml_display_unit_t* fmi3_xml_get_float32_variable_display_unit (fmi3_xml_float32_variable_t* v);
+fmi3_float32_t fmi3_xml_get_float32_variable_start (fmi3_xml_float32_variable_t* v);
+fmi3_float32_t* fmi3_xml_get_float32_variable_start_array(fmi3_xml_float32_variable_t* v);
+fmi3_float32_t fmi3_xml_get_float32_variable_min (fmi3_xml_float32_variable_t* v);
+fmi3_float32_t fmi3_xml_get_float32_variable_max (fmi3_xml_float32_variable_t* v);
+fmi3_float32_t fmi3_xml_get_float32_variable_nominal (fmi3_xml_float32_variable_t* v);
+fmi3_string_t fmi3_xml_get_float32_variable_quantity (fmi3_xml_float32_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_float32_variable_unbounded (fmi3_xml_float32_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_float32_variable_relative_quantity (fmi3_xml_float32_variable_t* v);
+
+fmi3_xml_int64_variable_t* fmi3_xml_get_variable_as_int64(fmi3_xml_variable_t*);
+fmi3_int64_t fmi3_xml_get_int64_variable_min (fmi3_xml_int64_variable_t* v);
+fmi3_int64_t fmi3_xml_get_int64_variable_max (fmi3_xml_int64_variable_t* v);
+fmi3_int64_t fmi3_xml_get_int64_variable_start (fmi3_xml_int64_variable_t* v);
+fmi3_int64_t* fmi3_xml_get_int64_variable_start_array(fmi3_xml_int64_variable_t* v);
+fmi3_string_t fmi3_xml_get_int64_variable_quantity (fmi3_xml_int64_variable_t* v);
+
+fmi3_xml_int32_variable_t* fmi3_xml_get_variable_as_int32(fmi3_xml_variable_t*);
+fmi3_int32_t fmi3_xml_get_int32_variable_min (fmi3_xml_int32_variable_t* v);
+fmi3_int32_t fmi3_xml_get_int32_variable_max (fmi3_xml_int32_variable_t* v);
+fmi3_int32_t fmi3_xml_get_int32_variable_start (fmi3_xml_int32_variable_t* v);
+fmi3_int32_t* fmi3_xml_get_int32_variable_start_array(fmi3_xml_int32_variable_t* v);
+fmi3_string_t fmi3_xml_get_int32_variable_quantity (fmi3_xml_int32_variable_t* v);
+
+fmi3_xml_int16_variable_t* fmi3_xml_get_variable_as_int16(fmi3_xml_variable_t*);
+fmi3_int16_t fmi3_xml_get_int16_variable_min (fmi3_xml_int16_variable_t* v);
+fmi3_int16_t fmi3_xml_get_int16_variable_max (fmi3_xml_int16_variable_t* v);
+fmi3_int16_t fmi3_xml_get_int16_variable_start (fmi3_xml_int16_variable_t* v);
+fmi3_int16_t* fmi3_xml_get_int16_variable_start_array(fmi3_xml_int16_variable_t* v);
+fmi3_string_t fmi3_xml_get_int16_variable_quantity (fmi3_xml_int16_variable_t* v);
+
+fmi3_xml_int8_variable_t* fmi3_xml_get_variable_as_int8(fmi3_xml_variable_t*);
+fmi3_int8_t fmi3_xml_get_int8_variable_min (fmi3_xml_int8_variable_t* v);
+fmi3_int8_t fmi3_xml_get_int8_variable_max (fmi3_xml_int8_variable_t* v);
+fmi3_int8_t fmi3_xml_get_int8_variable_start (fmi3_xml_int8_variable_t* v);
+fmi3_int8_t* fmi3_xml_get_int8_variable_start_array(fmi3_xml_int8_variable_t* v);
+fmi3_string_t fmi3_xml_get_int8_variable_quantity (fmi3_xml_int8_variable_t* v);
+
+fmi3_xml_uint64_variable_t* fmi3_xml_get_variable_as_uint64(fmi3_xml_variable_t*);
+fmi3_uint64_t fmi3_xml_get_uint64_variable_min (fmi3_xml_uint64_variable_t* v);
+fmi3_uint64_t fmi3_xml_get_uint64_variable_max (fmi3_xml_uint64_variable_t* v);
+fmi3_uint64_t fmi3_xml_get_uint64_variable_start (fmi3_xml_uint64_variable_t* v);
+fmi3_uint64_t* fmi3_xml_get_uint64_variable_start_array(fmi3_xml_uint64_variable_t* v);
+fmi3_string_t fmi3_xml_get_uint64_variable_quantity (fmi3_xml_uint64_variable_t* v);
+
+fmi3_xml_uint32_variable_t* fmi3_xml_get_variable_as_uint32(fmi3_xml_variable_t*);
+fmi3_uint32_t fmi3_xml_get_uint32_variable_min (fmi3_xml_uint32_variable_t* v);
+fmi3_uint32_t fmi3_xml_get_uint32_variable_max (fmi3_xml_uint32_variable_t* v);
+fmi3_uint32_t fmi3_xml_get_uint32_variable_start (fmi3_xml_uint32_variable_t* v);
+fmi3_uint32_t* fmi3_xml_get_uint32_variable_start_array(fmi3_xml_uint32_variable_t* v);
+fmi3_string_t fmi3_xml_get_uint32_variable_quantity (fmi3_xml_uint32_variable_t* v);
+
+fmi3_xml_uint16_variable_t* fmi3_xml_get_variable_as_uint16(fmi3_xml_variable_t*);
+fmi3_uint16_t fmi3_xml_get_uint16_variable_min (fmi3_xml_uint16_variable_t* v);
+fmi3_uint16_t fmi3_xml_get_uint16_variable_max (fmi3_xml_uint16_variable_t* v);
+fmi3_uint16_t fmi3_xml_get_uint16_variable_start (fmi3_xml_uint16_variable_t* v);
+fmi3_uint16_t* fmi3_xml_get_uint16_variable_start_array(fmi3_xml_uint16_variable_t* v);
+fmi3_string_t fmi3_xml_get_uint16_variable_quantity (fmi3_xml_uint16_variable_t* v);
+
+fmi3_xml_uint8_variable_t* fmi3_xml_get_variable_as_uint8(fmi3_xml_variable_t*);
+fmi3_uint8_t fmi3_xml_get_uint8_variable_min (fmi3_xml_uint8_variable_t* v);
+fmi3_uint8_t fmi3_xml_get_uint8_variable_max (fmi3_xml_uint8_variable_t* v);
+fmi3_uint8_t fmi3_xml_get_uint8_variable_start (fmi3_xml_uint8_variable_t* v);
+fmi3_uint8_t* fmi3_xml_get_uint8_variable_start_array(fmi3_xml_uint8_variable_t* v);
+fmi3_string_t fmi3_xml_get_uint8_variable_quantity (fmi3_xml_uint8_variable_t* v);
+
+fmi3_xml_string_variable_t* fmi3_xml_get_variable_as_string(fmi3_xml_variable_t*);
+fmi3_string_t  fmi3_xml_get_string_variable_start(fmi3_xml_string_variable_t* v);
+fmi3_string_t* fmi3_xml_get_string_variable_start_array(fmi3_xml_string_variable_t* v);
+
+fmi3_xml_bool_variable_t* fmi3_xml_get_variable_as_boolean(fmi3_xml_variable_t*);
+fmi3_boolean_t fmi3_xml_get_boolean_variable_start(fmi3_xml_bool_variable_t* v);
+fmi3_boolean_t* fmi3_xml_get_boolean_variable_start_array(fmi3_xml_bool_variable_t* v);
+
+fmi3_xml_binary_variable_t* fmi3_xml_get_variable_as_binary(fmi3_xml_variable_t*);
+size_t         fmi3_xml_get_binary_variable_start_size(fmi3_xml_binary_variable_t* v);
+fmi3_binary_t  fmi3_xml_get_binary_variable_start(fmi3_xml_binary_variable_t* v);
+fmi3_binary_t* fmi3_xml_get_binary_variable_start_array(fmi3_xml_binary_variable_t* v);
+size_t*        fmi3_xml_get_binary_variable_start_array_sizes(fmi3_xml_binary_variable_t* v);
+size_t         fmi3_xml_get_binary_variable_start_array_size(fmi3_xml_binary_variable_t* v);
+fmi3_string_t fmi3_xml_get_binary_variable_mime_type(fmi3_xml_binary_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_binary_variable_has_max_size(fmi3_xml_binary_variable_t* v);
+size_t fmi3_xml_get_binary_variable_max_size(fmi3_xml_binary_variable_t* v);
+
+fmi3_xml_clock_variable_t* fmi3_xml_get_variable_as_clock(fmi3_xml_variable_t*);
+fmi3_boolean_t fmi3_xml_get_clock_variable_can_be_deactivated(fmi3_xml_clock_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_clock_variable_has_priority(fmi3_xml_clock_variable_t* v);
+fmi3_uint32_t fmi3_xml_get_clock_variable_priority(fmi3_xml_clock_variable_t* v);
+fmi3_interval_variability_enu_t fmi3_xml_get_clock_variable_interval_variability(fmi3_xml_clock_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_clock_variable_has_interval_decimal(fmi3_xml_clock_variable_t* v);
+fmi3_float64_t fmi3_xml_get_clock_variable_interval_decimal(fmi3_xml_clock_variable_t* v);
+fmi3_float64_t fmi3_xml_get_clock_variable_shift_decimal(fmi3_xml_clock_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_clock_variable_supports_fraction(fmi3_xml_clock_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_clock_variable_has_resolution(fmi3_xml_clock_variable_t* v);
+fmi3_uint64_t fmi3_xml_get_clock_variable_resolution(fmi3_xml_clock_variable_t* v);
+fmi3_boolean_t fmi3_xml_get_clock_variable_has_interval_counter(fmi3_xml_clock_variable_t* v);
+fmi3_uint64_t fmi3_xml_get_clock_variable_interval_counter(fmi3_xml_clock_variable_t* v);
+fmi3_uint64_t fmi3_xml_get_clock_variable_shift_counter(fmi3_xml_clock_variable_t* v);
+
+fmi3_xml_enum_variable_t* fmi3_xml_get_variable_as_enum(fmi3_xml_variable_t*);
+fmi3_string_t fmi3_xml_get_enum_variable_quantity(fmi3_xml_enum_variable_t* v);
+fmi3_int64_t fmi3_xml_get_enum_variable_start(fmi3_xml_enum_variable_t* v);
+fmi3_int64_t* fmi3_xml_get_enum_variable_start_array(fmi3_xml_enum_variable_t* v);
+fmi3_int64_t fmi3_xml_get_enum_variable_min(fmi3_xml_enum_variable_t* v);
+fmi3_int64_t fmi3_xml_get_enum_variable_max(fmi3_xml_enum_variable_t* v);
+
+fmi3_xml_dimension_list_t* fmi3_xml_get_variable_dimension_list(fmi3_xml_variable_t* v);
+size_t fmi3_xml_get_dimension_list_size(fmi3_xml_dimension_list_t* dl);
+fmi3_xml_dimension_t* fmi3_xml_get_dimension(fmi3_xml_dimension_list_t* dl, size_t idx);
+int fmi3_xml_get_dimension_has_vr(fmi3_xml_dimension_t* dim);
+int fmi3_xml_get_dimension_has_start(fmi3_xml_dimension_t* dim);
+fmi3_uint64_t fmi3_xml_get_dimension_start(fmi3_xml_dimension_t* dim);
+fmi3_value_reference_t fmi3_xml_get_dimension_vr(fmi3_xml_dimension_t* dim);
+
+void fmi3_xml_free_variable(jm_callbacks* callbacks, fmi3_xml_variable_t* var);
+
+/**
+@}
+*/
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/FMIL/src/ZIP/include/FMI/fmi_miniunz.h
+++ b/FMIL/src/ZIP/include/FMI/fmi_miniunz.h
@@ -1,0 +1,13 @@
+#ifndef FMI_MINIUNZ_H
+#define FMI_MINIUNZ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int fmi_miniunz(const char* zip_file_path, const char* output_folder);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* End of header file FMI_MINIUNZ_H */

--- a/FMIL/src/ZIP/include/FMI/fmi_minizip.h
+++ b/FMIL/src/ZIP/include/FMI/fmi_minizip.h
@@ -1,0 +1,12 @@
+#ifndef FMI_MINIZIP_H
+#define FMI_MINIZIP_H
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
+int fmi_minizip(const char* zip_file_path, int n_files_to_zip, const char** files_to_zip); /* Renamed the main function */
+
+#ifdef __cplusplus 
+}
+#endif
+#endif /* End of header file FMI_MINIZIP_H */


### PR DESCRIPTION
#224 landed without 30 header files. `FMIL/.gitignore` contains

```
include/
```

which, being **unanchored**, matches a directory named `include` at any depth — not just
the generated `FMIL/include/` it is meant for, but `src/CAPI/include/`,
`src/Import/include/`, `src/Util/include/`, `src/XML/include/` and `src/ZIP/include/`,
where the real headers live.

The rule predates #224 and was harmless, because the files under those directories were
already tracked and git does not apply ignore rules to tracked files. #224 deleted the
whole `FMIL` directory and re-added it, so every header whose path was **new** in 3.0.4 —
all of `FMI3/`, plus a few new FMI1/FMI2 ones — was silently skipped by `git add`.

The pattern is now anchored to `/include/`, and the 30 missing headers are added.

## Why nothing caught it locally

The CMake build of OpenModelica reads these headers straight out of the working tree, so a
tree that still has the files builds fine. A fresh checkout does not have them, and the
standalone FMIL build that `OMCompiler/Makefile.common` drives fails at configure time:

```
CMake Error at Config.cmake/fmicapi.cmake:45 (add_library):
  Cannot find source file:
    .../FMIL/src/CAPI/include/FMI3/fmi3_capi.h
...
CMake Error at Config.cmake/jmutil.cmake:93 (add_library):
  No SOURCES given to target: jmutils
CMake Error at CMakeLists.txt:351 (add_library):
  No SOURCES given to target: fmilib_shared
```

That is what OpenModelica/OpenModelica#16251 hit on Jenkins (`Makefile.common:456`).

## Also: six zlib Makefiles

Dropped by #224 for a related reason — the vendoring excluded `Makefile` to leave out FMI
Library's own top-level one, and that pattern matched at every depth too. They are unused
by the CMake build, but the vendored copy should be upstream's tree, so they are restored.

With this, the vendored tree is **exactly** upstream 3.0.4 apart from the deliberate
omissions (`Test/`, `dev/`, `build/`, `Jenkinsfile.groovy`, the top-level `Makefile`,
`ThirdParty/Catch2/`, `.github/`, `.vscode/`, `.devcontainer/`) and the OpenModelica
patches.

## Testing

Ran the configure/build/install that the autotools build performs:

```
cmake -S OMCompiler/3rdParty/FMIL -B build \
      -DFMILIB_BUILD_SHARED_LIB=ON -DFMILIB_BUILD_TESTS=OFF \
      -DOMC_ZLIB_LIBRARY=... -DOMC_ZLIB_INCLUDE_DIR=...
```

It now succeeds, installs the FMI1/FMI2/FMI3/JM headers, and `libfmilib_shared.so` exports
379 `fmi3_import_*` symbols.

Ticket: OpenModelica/OpenModelica#16173

---
generated by Claude Code
