### PR TITLE
[LIBFFI] fix AARCH64, add tramp.c to SOURCES_LIST

### DIFF
--- a/libffi/CMakeLists.txt
+++ b/libffi/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 
 set(SOURCES_LIST
     src/closures.c
+    src/tramp.c
     src/java_raw_api.c
     src/prep_cif.c
     src/raw_api.c


### PR DESCRIPTION
When updating libffi in 2024, the `tramp.c` was added to the official libffi repo, but not added to the `SOURCE_LIST` of the 3rdParty `CMakeLists.txt`. This was no problem on Linux x86, but it failed on ARM as this architecture requires its content / symbols.

Fix: add `tramp.c` to `SOURCES_LIST` as done in the official libffi autoconf build